### PR TITLE
Update week 1 to match current calendar

### DIFF
--- a/module1/week_1.md
+++ b/module1/week_1.md
@@ -12,6 +12,7 @@ layout: page
 * [Introducing Arrays](lessons/arrays_101) ([Video](https://www.youtube.com/watch?v=nlwU1YtQ9SU))
 * [Flow Control](lessons/flow_control) ([Video](https://www.youtube.com/watch?v=iZkQWR9_RpY))
 * [Exploring `.each` and Exercises](lessons/primer_on_each)
+* [Core Types Exercises](https://github.com/turingschool/ruby-exercises/tree/master/core-types)
 * [Methods, Arguments, Scopes](lessons/methods_arguments_and_scopes.markdown)
 * [Classes and Instance Methods](lessons/classes_instances_methods)
 
@@ -21,16 +22,14 @@ layout: page
 * [Pseudocoding](student_homework/pseudocoding_homework.md)
 * [Bad Connection](student_homework/bad_connection.md)
 * [SuperFizz](student_homework/super_fizz.md)
+* [Sorting Suite](projects/sorting_suite.markdown)
 
 ## Projects
 
 * [Credit Check](projects/credit_check.markdown)
-* [Sorting Suite](projects/sorting_suite.markdown)
 
 ## Exercises and Other Relevant Links
 
-* [Enumerable Exercises](https://github.com/turingschool/enums-exercises)
-* [Core Types Exercises](https://github.com/turingschool/ruby-exercises/tree/master/core-types)
 * [Environment Setup](lessons/environment_setup) ([Video](https://vimeo.com/154607937))
 * [Terminal and Editor](https://github.com/turingschool/curriculum/blob/master/source/academy/workshops/terminal_and_editor.markdown)
 * [Working with Strings and Integers](https://github.com/turingschool/challenges/blob/master/working_with_strings_and_integers.markdown)

--- a/module1/week_1.md
+++ b/module1/week_1.md
@@ -13,7 +13,7 @@ layout: page
 * [Flow Control](lessons/flow_control) ([Video](https://www.youtube.com/watch?v=iZkQWR9_RpY))
 * [Exploring `.each` and Exercises](lessons/primer_on_each)
 * [Methods, Arguments, Scopes](lessons/methods_arguments_and_scopes.markdown)
-* [Classes and Instance Methods](lessons/classes_instances_methods) ([Video](https://www.twitch.tv/worace/v/56378715))
+* [Classes and Instance Methods](lessons/classes_instances_methods)
 
 ## Homework
 
@@ -25,8 +25,8 @@ layout: page
 
 * [Enumerable Exercises](https://github.com/turingschool/enums-exercises)
 * [Core Types Exercises](https://github.com/turingschool/ruby-exercises/tree/master/core-types)
-* [Credit Check](projects/credit_check.markdown)
 * [Sorting Suite](projects/sorting_suite.markdown)
+* [Credit Check](projects/credit_check.markdown)
 
 ## Other Relevant Links
 

--- a/module1/week_1.md
+++ b/module1/week_1.md
@@ -12,7 +12,6 @@ layout: page
 * [Introducing Arrays](lessons/arrays_101) ([Video](https://www.youtube.com/watch?v=nlwU1YtQ9SU))
 * [Flow Control](lessons/flow_control) ([Video](https://www.youtube.com/watch?v=iZkQWR9_RpY))
 * [Exploring `.each` and Exercises](lessons/primer_on_each)
-* [Sorting Suite](projects/sorting_suite.markdown)
 * [Methods, Arguments, Scopes](lessons/methods_arguments_and_scopes.markdown)
 * [Classes and Instance Methods](lessons/classes_instances_methods)
 
@@ -26,6 +25,7 @@ layout: page
 ## Projects
 
 * [Credit Check](projects/credit_check.markdown)
+* [Sorting Suite](projects/sorting_suite.markdown)
 
 ## Exercises and Other Relevant Links
 

--- a/module1/week_1.md
+++ b/module1/week_1.md
@@ -12,6 +12,7 @@ layout: page
 * [Introducing Arrays](lessons/arrays_101) ([Video](https://www.youtube.com/watch?v=nlwU1YtQ9SU))
 * [Flow Control](lessons/flow_control) ([Video](https://www.youtube.com/watch?v=iZkQWR9_RpY))
 * [Exploring `.each` and Exercises](lessons/primer_on_each)
+* [Sorting Suite](projects/sorting_suite.markdown)
 * [Methods, Arguments, Scopes](lessons/methods_arguments_and_scopes.markdown)
 * [Classes and Instance Methods](lessons/classes_instances_methods)
 
@@ -22,15 +23,14 @@ layout: page
 * [Bad Connection](student_homework/bad_connection.md)
 * [SuperFizz](student_homework/super_fizz.md)
 
-## Projects and Exercises
+## Projects
+
+* [Credit Check](projects/credit_check.markdown)
+
+## Exercises and Other Relevant Links
 
 * [Enumerable Exercises](https://github.com/turingschool/enums-exercises)
 * [Core Types Exercises](https://github.com/turingschool/ruby-exercises/tree/master/core-types)
-* [Sorting Suite](projects/sorting_suite.markdown)
-* [Credit Check](projects/credit_check.markdown)
-
-## Other Relevant Links
-
 * [Environment Setup](lessons/environment_setup) ([Video](https://vimeo.com/154607937))
 * [Terminal and Editor](https://github.com/turingschool/curriculum/blob/master/source/academy/workshops/terminal_and_editor.markdown)
 * [Working with Strings and Integers](https://github.com/turingschool/challenges/blob/master/working_with_strings_and_integers.markdown)

--- a/module1/week_1.md
+++ b/module1/week_1.md
@@ -5,7 +5,6 @@ layout: page
 
 ## Lessons
 
-* [Environment Setup](lessons/environment_setup) ([Video](https://vimeo.com/154607937))
 * [Success at Turing](lessons/success_at_turing)
 * [Intro to Git](lessons/intro_to_git)
 * [Strings and Integers](lessons/strings_and_integers)
@@ -13,9 +12,8 @@ layout: page
 * [Introducing Arrays](lessons/arrays_101) ([Video](https://www.youtube.com/watch?v=nlwU1YtQ9SU))
 * [Flow Control](lessons/flow_control) ([Video](https://www.youtube.com/watch?v=iZkQWR9_RpY))
 * [Exploring `.each` and Exercises](lessons/primer_on_each)
-<!-- * [Core Types (Foxtrot)](https://github.com/turingschool/ruby-exercises/tree/master/core-types) -->
-* [Classes and Instance Methods](lessons/classes_instances_methods) ([Video](https://www.twitch.tv/worace/v/56378715))
 * [Methods, Arguments, Scopes](lessons/methods_arguments_and_scopes.markdown)
+* [Classes and Instance Methods](lessons/classes_instances_methods) ([Video](https://www.twitch.tv/worace/v/56378715))
 
 ## Homework
 
@@ -32,6 +30,7 @@ layout: page
 
 ## Other Relevant Links
 
+* [Environment Setup](lessons/environment_setup) ([Video](https://vimeo.com/154607937))
 * [Terminal and Editor](https://github.com/turingschool/curriculum/blob/master/source/academy/workshops/terminal_and_editor.markdown)
 * [Working with Strings and Integers](https://github.com/turingschool/challenges/blob/master/working_with_strings_and_integers.markdown)
 * [Eloquent Ruby Ch 3 & 4 Reading](https://github.com/turingschool/challenges/blob/master/eloquent_ruby_arrays_and_strings.markdown)
@@ -40,5 +39,6 @@ layout: page
 
 
 <!-- ## OLD:
+* [Core Types (Foxtrot)](https://github.com/turingschool/ruby-exercises/tree/master/core-types)
 * [Mythical Creatures](https://github.com/turingschool/ruby-exercises/blob/master/mythical-creatures/)
  -->

--- a/module1/week_1.md
+++ b/module1/week_1.md
@@ -17,6 +17,7 @@ layout: page
 
 ## Homework
 
+* [Working With Strings & Integers](https://github.com/turingschool/challenges/blob/master/working_with_strings_and_integers.markdown)
 * [Pseudocoding](student_homework/pseudocoding_homework.md)
 * [Bad Connection](student_homework/bad_connection.md)
 * [SuperFizz](student_homework/super_fizz.md)

--- a/module1/week_2.md
+++ b/module1/week_2.md
@@ -17,9 +17,11 @@ layout: page
 *   [Academic Integrity](lessons/academic_integrity)
 
 ## Projects and Exercises
-*   [Jungle Beat](projects/jungle_beat)
-*   [Date Night](projects/date_night)
-*   [Enigma](projects/enigma)
+
+* [Enumerable Exercises](https://github.com/turingschool/enums-exercises)
+* [Jungle Beat](projects/jungle_beat)
+* [Date Night](projects/date_night)
+* [Enigma](projects/enigma)
 
 ## Resources
 


### PR DESCRIPTION
@mikedao @AliSchlereth 

Hey group! Making small updates to the week 1 page to match what I see in the calendar. Wondering about the following:

* Currently we have SuperFizz linked from the week 1 page, but I don't see it in our calendar. Is it scheduled for homework for one of the days and I'm just not seeing it?
* Am I correct in thinking that Sorting Suite is now just an hour and a half class and not really a project? It looks like we have that on the same day that we kick off Credit Check. If so, propose that we move it to the `Lessons` section of this page.
* Where do the Enumerable and Core Types exercises fit in? If they're tied to a specific lesson (or if we introduce them in a specific lesson) recommend including them there. Thoughts?
* I don't see time specifically dedicated to Environment Setup. I think that makes sense (assume they will have completed it before they come in), but assume some portion of the students won't have their computers ready day 1, minute 1. Is there any specific time we've used in the past to troubleshoot?

Let me know what you think, and if you see any other disconnects between the Week 1 page and the calendar. Thanks!