### PR TITLE
Changes SQL type in migration from DATETIME to TIMESTAMP

### DIFF
--- a/module4/lessons/sql-in-node.md
+++ b/module4/lessons/sql-in-node.md
@@ -177,7 +177,7 @@ exports.up = function(knex, Promise) {
   let createQuery = `CREATE TABLE secrets(
     id SERIAL PRIMARY KEY NOT NULL,
     message TEXT,
-    created_at DATETIME
+    created_at TIMESTAMP
   )`;
   return knex.raw(createQuery);
 };


### PR DESCRIPTION
DATETIME data type doesn't exist in postgresql. Here is the documentation for reference: https://www.postgresql.org/docs/9.4/static/datatype-datetime.html.