### PR TITLE
[WIP] As project rubric alignment

### DIFF
--- a/module1/projects/battleship.markdown
+++ b/module1/projects/battleship.markdown
@@ -252,12 +252,12 @@ The project will be assessed with the following rubric:
 * 2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
 * 1:  Application generates syntax error or crashes during execution
 
-### 2. Enumerable & Collections
+### 2. Breaking Logic into Components
 
-* 4: Application consistently makes use of the best-choice Enumerable methods
-* 3: Application demonstrates comfortable use of several Enumerable techniques
-* 2: Application demonstrates functional knowledge of Enumerable but only uses the most basic techniques
-* 1: Application demonstrates deficiencies with Enumerable and struggles with collections
+* 4: Application is expertly divided into logical components such that individual pieces could be reused or replaced without difficulty
+* 3: Application effectively breaks logical components apart with clear intent and usage
+* 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
+* 1: Application logic shows poor decomposition with too much logic mashed together
 
 ### 3. Test-Driven Development
 
@@ -266,14 +266,7 @@ The project will be assessed with the following rubric:
 * 2: Application makes some use of tests, but the coverage is insufficient
 * 1: Application does not demonstrate strong use of TDD
 
-### 4. Encapsulation / Breaking Logic into Components
-
-* 4: Application is expertly divided into logical components such that individual pieces could be reused or replaced without difficulty
-* 3: Application effectively breaks logical components apart with clear intent and usage
-* 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
-* 1: Application logic shows poor decomposition with too much logic mashed together
-
-### 5. Functional Expectations
+### 4. Functional Expectations
 
 * 4: Application meets all requirements, and implements one extension properly.
 * 3: Application meets all requirements as laid out per the specification.

--- a/module1/projects/black_thursday.markdown
+++ b/module1/projects/black_thursday.markdown
@@ -63,12 +63,12 @@ The project will be assessed with the following guidelines:
 *   2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
 *   1:  Application generates syntax error or crashes during execution
 
-### 2. Enumerable & Collections
+### 2. Breaking Logic into Components
 
-*   4: Application consistently makes use of the best-choice Enumerable methods
-*   3: Application demonstrates comfortable use of appropriate Enumerable methods
-*   2: Application demonstrates functional knowledge of Enumerable but only uses the most basic techniques
-*   1: Application demonstrates deficiencies with Enumerable and struggles with collections
+*   4: Application is expertly divided into logical components each with a clear, single responsibility
+*   3: Application effectively breaks logical components apart but breaks the principle of SRP
+*   2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
+*   1: Application logic shows poor decomposition with too much logic mashed together
 
 ### 3. Test-Driven Development
 
@@ -77,21 +77,14 @@ The project will be assessed with the following guidelines:
 *   2: Application makes some use of tests, but the coverage is insufficient
 *   1: Application does not demonstrate strong use of TDD
 
-### 4. Encapsulation / Breaking Logic into Components
-
-*   4: Application is expertly divided into logical components each with a clear, single responsibility
-*   3: Application effectively breaks logical components apart but breaks the principle of SRP
-*   2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
-*   1: Application logic shows poor decomposition with too much logic mashed together
-
-### 5. Functional Expectations
+### 4. Functional Expectations
 
 *   4: Application implements iterations 0, 1, 2, 3, (4 or 5), and features of your own design
 *   3: Application implements iterations 0, 1, 2, 3, and either 4 or 5
 *   2: Application implements iterations 0, 1, 2, and 3
 *   1: Application does not fully implement iterations 0, 1, 2, and 3
 
-### 6. Code Sanitation
+### 5. Code Sanitation
 
 The output from `rake sanitation:all` shows...
 

--- a/module1/projects/complete_me.markdown
+++ b/module1/projects/complete_me.markdown
@@ -261,26 +261,26 @@ Can you create a graphical user interface for your code? Something that a "norma
 
 The project will be assessed with the following rubric:
 
-### 1. Fundamental Ruby & Style
+### 1. Ruby Syntax & Style
 
 * 4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring
 * 3:  Application shows strong effort towards organization, content, and refactoring
 * 2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
 * 1:  Application generates syntax error or crashes during execution
 
-### 2. Test-Driven Development
-
-* 4: Application is broken into components which are well tested in both isolation and integration using appropriate data
-* 3: Application is well tested but does not balance isolation and integration tests, using only the data necessary to test the functionality
-* 2: Application makes some use of tests, but the coverage is insufficient
-* 1: Application does not demonstrate strong use of TDD
-
-### 3. Encapsulation / Breaking Logic into Components
+### 2. Breaking Logic into Components
 
 * 4: Application is expertly divided into logical components each with a clear, single responsibility
 * 3: Application effectively breaks logical components apart but breaks the principle of SRP
 * 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
 * 1: Application logic shows poor decomposition with too much logic mashed together
+
+### 3. Test-Driven Development
+
+* 4: Application is broken into components which are well tested in both isolation and integration using appropriate data
+* 3: Application is well tested but does not balance isolation and integration tests, using only the data necessary to test the functionality
+* 2: Application makes some use of tests, but the coverage is insufficient
+* 1: Application does not demonstrate strong use of TDD
 
 ### 4. Functional Expectations
 

--- a/module1/projects/credit_check.markdown
+++ b/module1/projects/credit_check.markdown
@@ -110,14 +110,14 @@ If helpful, you can use the following sample data:
 
 The project will be assessed with the following guidelines:
 
-### 1. Fundamental Ruby & Style
+### 1. Ruby Syntax & Style
 
 * 4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring
 * 3:  Application shows strong effort towards organization, content, and refactoring
 * 2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
 * 1:  Application generates syntax error or crashes during execution
 
-### 2. Encapsulation / Breaking Logic into Components
+### 2. Breaking Logic into Components
 
 * 4: Application is expertly divided into logical components each with a clear, single responsibility
 * 3: Application effectively breaks logical components apart but breaks the principle of SRP

--- a/module1/projects/date_night.markdown
+++ b/module1/projects/date_night.markdown
@@ -201,26 +201,26 @@ Note that any children of the deleted node should still be present in the tree.
 
 The project will be assessed with the following rubric:
 
-### 1. Fundamental Ruby & Style
+### 1. Ruby Syntax & Style
 
 * 4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring
 * 3:  Application shows strong effort towards organization, content, and refactoring
 * 2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
 * 1:  Application generates syntax error or crashes during execution
 
-### 2. Test-Driven Development
-
-* 4: Application is broken into components which are well tested in both isolation and integration using appropriate data
-* 3: Application is well tested but does not balance isolation and integration tests, using only the data necessary to test the functionality
-* 2: Application makes some use of tests, but the coverage is insufficient
-* 1: Application does not demonstrate strong use of TDD
-
-### 3. Encapsulation / Breaking Logic into Components
+### 2. Breaking Logic into Components
 
 * 4: Application is expertly divided into logical components each with a clear, single responsibility
 * 3: Application effectively breaks logical components apart but breaks the principle of SRP
 * 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
 * 1: Application logic shows poor decomposition with too much logic mashed together
+
+### 3. Test-Driven Development
+
+* 4: Application is broken into components which are well tested in both isolation and integration using appropriate data
+* 3: Application is well tested but does not balance isolation and integration tests, using only the data necessary to test the functionality
+* 2: Application makes some use of tests, but the coverage is insufficient
+* 1: Application does not demonstrate strong use of TDD
 
 ### 4. Functional Expectations
 

--- a/module1/projects/enigma.markdown
+++ b/module1/projects/enigma.markdown
@@ -174,26 +174,26 @@ Please make sure that, before your evaluation, your project has each of the foll
 
 The project will be assessed with the following rubric:
 
-### 1. Fundamental Ruby & Style
+### 1. Ruby Syntax & Style
 
 * 4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring
 * 3:  Application shows strong effort towards organization, content, and refactoring
 * 2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
 * 1:  Application generates syntax error or crashes during execution
 
-### 2. Test-Driven Development
-
-* 4: Application is broken into components which are well tested in both isolation and integration
-* 3: Application uses tests to exercise core functionality, but has some gaps in coverage or leaves edge cases untested.
-* 2: Application tests some components but has many gaps in coverage.
-* 1: Application does not demonstrate strong use of TDD
-
-### 3. Encapsulation / Breaking Logic into Components
+### 2. Breaking Logic into Components
 
 * 4: Application is expertly divided into logical components each with a clear, single responsibility
 * 3: Application effectively breaks logical components apart but breaks the principle of SRP
 * 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
 * 1: Application logic shows poor decomposition with too much logic mashed together
+
+### 3. Test-Driven Development
+
+* 4: Application is broken into components which are well tested in both isolation and integration
+* 3: Application uses tests to exercise core functionality, but has some gaps in coverage or leaves edge cases untested.
+* 2: Application tests some components but has many gaps in coverage.
+* 1: Application does not demonstrate strong use of TDD
 
 ### 4. Functional Expectations
 

--- a/module1/projects/headcount.markdown
+++ b/module1/projects/headcount.markdown
@@ -163,12 +163,12 @@ The project will be assessed with the following guidelines:
 * 2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
 * 1:  Application generates syntax error or crashes during execution
 
-### 2. Enumerable & Collections
+### 2. Breaking Logic into Components
 
-* 4: Application consistently makes use of the best-choice Enumerable methods
-* 3: Application demonstrates comfortable use of appropriate Enumerable methods
-* 2: Application demonstrates functional knowledge of Enumerable but only uses the most basic techniques
-* 1: Application demonstrates deficiencies with Enumerable and struggles with collections
+* 4: Application is expertly divided into logical components each with a clear, single responsibility
+* 3: Application effectively breaks logical components apart but breaks the principle of SRP
+* 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
+* 1: Application logic shows poor decomposition with too much logic mashed together
 
 ### 3. Test-Driven Development
 
@@ -177,21 +177,14 @@ The project will be assessed with the following guidelines:
 * 2: Application makes some use of tests, but the coverage is insufficient
 * 1: Application does not demonstrate strong use of TDD
 
-### 4. Encapsulation / Breaking Logic into Components
-
-* 4: Application is expertly divided into logical components each with a clear, single responsibility
-* 3: Application effectively breaks logical components apart but breaks the principle of SRP
-* 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
-* 1: Application logic shows poor decomposition with too much logic mashed together
-
-### 5. Functional Expectations
+### 4. Functional Expectations
 
 * 4: Application fulfills all expectations of Iterations 0 - 6 *as well as* one additional, comparable Iteration of your own design.
 * 3: Application fulfills expectations of Iterations 0 - 4 *as well as* one of Iterations 5 or 6
 * 2: Application has some missing functionality but no crashes
 * 1: Application crashes during normal usage
 
-### 6. Code Sanitation
+### 5. Code Sanitation
 
 The output from `rake sanitation:all` shows...
 

--- a/module1/projects/http_yeah_you_know_me.markdown
+++ b/module1/projects/http_yeah_you_know_me.markdown
@@ -387,14 +387,14 @@ To demonstrate this functionality, additionally add a new GET endpoint `/sleepy`
 
 The project will be assessed with the following rubric:
 
-### 1. Fundamental Ruby & Style
+### 1. Ruby Syntax & Style
 
 * 4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring
 * 3:  Application shows strong effort towards organization, content, and refactoring
 * 2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
 * 1:  Application generates syntax error or crashes during execution
 
-### 2. Encapsulation / Breaking Logic into Components
+### 2. Breaking Logic into Components
 
 * 4: Application is expertly divided into logical components each with a clear, single responsibility
 * 3: Application effectively breaks logical components apart but breaks the principle of SRP

--- a/module1/projects/jungle_beat.markdown
+++ b/module1/projects/jungle_beat.markdown
@@ -100,19 +100,20 @@ Need some help on Linked Lists? You can check out some of the following resource
 
 The project will be assessed with the following rubric:
 
-### 1. Fundamental Ruby & Style
+### 1. Ruby Syntax & Style
 
 * 4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring
 * 3:  Application shows strong effort towards organization, content, and refactoring
 * 2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
 * 1:  Application generates syntax error or crashes during execution
 
-### 2. Looping *or* Recursion
+### 2. Breaking Logic into Components
 
-* 4: Application makes excellent use of loop/recursion techniques
-* 3: Application makes effective use of loop/recursion techniques
-* 2: Application has issues with loop/recursion techniques or mixes them inappropriately
-* 1: Application struggles to loop/recurse at all
+* 4: Application is expertly divided into logical components each with a clear, single responsibility
+* 3: Application effectively breaks logical components apart but breaks the principle of SRP
+* 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
+* 1: Application logic shows poor decomposition with too much logic mashed together
+
 
 ### 3. Test-Driven Development
 
@@ -121,14 +122,7 @@ The project will be assessed with the following rubric:
 * 2: Application makes some use of tests, but the coverage is insufficient
 * 1: Application does not demonstrate strong use of TDD
 
-### 4. Encapsulation / Breaking Logic into Components
-
-* 4: Application is expertly divided into logical components each with a clear, single responsibility
-* 3: Application effectively breaks logical components apart but breaks the principle of SRP
-* 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
-* 1: Application logic shows poor decomposition with too much logic mashed together
-
-### 5. Functional Expectations
+### 4. Functional Expectations
 
 * 4: Application meets all requirements, and implements one extension properly.
 * 3: Application meets all requirements as laid out per the specification.

--- a/module1/projects/learning_goals_by_project.md
+++ b/module1/projects/learning_goals_by_project.md
@@ -1,0 +1,78 @@
+## Learning Goals by Project   
+
+### Credit Check  
+None Listed  
+
+### Sorting Suite  
+None Listed  
+
+### Mastermind  
+#### Learning Goals / Areas of Focus
+*   Apply principles of flow control across multiple methods
+*   Practice breaking a program into logical components
+*   Learn to implement a REPL interface
+*   Apply Enumerable techniques in a real context
+
+### Jungle Beat  
+None listed  
+
+### Enigma  
+#### Learning Goals / Areas of Focus
+* Practice breaking a program into logical components
+* Testing components in isolation and in combination
+* Applying Enumerable techniques in a real context
+* Reading text from and writing text to files
+
+### NightWriter  
+#### Learning Goals / Areas of Focus
+* Practice breaking a program into logical components
+* Testing components in isolation and in combination
+* Applying Enumerable techniques in a real context
+* Reading text from and writing text to files
+
+### Date Night  
+None listed  
+
+
+### CompleteMe  
+None listed  
+
+### HTTP Yeah 
+#### Learning Goals
+* Practice breaking a workflow into a system of coordinating components
+* Practice using TDD at the unit, integration, and acceptance levels
+* Understand how the HTTP request/response cycle works
+* Practice implementing basic HTTP requests and responses  
+
+### Hyde  
+#### Learning Goals
+* Use tests to drive both the design and implementation of code
+* Decompose a large application into components
+* Use test fixtures instead of actual data when testing
+* Connect related objects together through references
+* Learn an agile approach to building software
+
+
+### Battleship  
+#### Learning Goals / Areas of Focus
+* Proficiently use TDD to drive development
+* Practice breaking a program into logical components
+* Practice implementing a useable REPL interface
+* Apply previously learned Enumerable techniques in a real context
+
+### Black Thursday  
+#### Learning Goals
+*   Use tests to drive both the design and implementation of code
+*   Decompose a large application into components
+*   Use test fixtures instead of actual data when testing
+*   Connect related objects together through references
+*   Learn an agile approach to building software  
+
+### Headcount  
+#### Learning Goals
+
+* Use tests to drive both the design and implementation of code
+* Decompose a large application into components such as parsers, repositories, and analysis tools
+* Use test fixtures instead of actual data when testing
+* Connect related objects together through references
+* Learn an agile approach to building software

--- a/module1/projects/mastermind.markdown
+++ b/module1/projects/mastermind.markdown
@@ -143,12 +143,12 @@ The project will be assessed with the following rubric:
 *   2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
 *   1:  Application generates syntax error or crashes during execution
 
-### 2. Enumerable & Collections
+### 2. Breaking Logic into Components
 
-*   4: Application consistently makes use of the best-choice Enumerable methods
-*   3: Application demonstrates comfortable use of appropriate Enumerable methods
-*   2: Application demonstrates functional knowledge of Enumerable but only uses the most basic techniques
-*   1: Application demonstrates deficiencies with Enumerable and struggles with collections
+*   4: Application is expertly divided into logical components each with a clear, single responsibility
+*   3: Application effectively breaks logical components apart but breaks the principle of SRP
+*   2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
+*   1: Application logic shows poor decomposition with too much logic mashed together
 
 ### 3. Test-Driven Development
 
@@ -157,14 +157,7 @@ The project will be assessed with the following rubric:
 *   2: Application makes some use of tests, but the coverage is insufficient
 *   1: Application does not demonstrate strong use of TDD
 
-### 4. Encapsulation / Breaking Logic into Components
-
-*   4: Application is expertly divided into logical components each with a clear, single responsibility
-*   3: Application effectively breaks logical components apart but breaks the principle of SRP
-*   2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
-*   1: Application logic shows poor decomposition with too much logic mashed together
-
-### 5. Functional Expectations
+### 4. Functional Expectations
 
 *   4: Application meets all requirements, and implements one extension properly.
 *   3: Application meets all requirements as laid out per the specification.

--- a/module1/projects/night_writer.markdown
+++ b/module1/projects/night_writer.markdown
@@ -200,26 +200,26 @@ to submit additional examples, especially for the extensions, as pull requests.
 
 The project will be assessed with the following rubric:
 
-### 1. Fundamental Ruby & Style
+### 1. Ruby Syntax & Style
 
 * 4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring
 * 3:  Application shows strong effort towards organization, content, and refactoring
 * 2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
 * 1:  Application generates syntax error or crashes during execution
 
-### 2. Test-Driven Development
-
-* 4: Application is broken into components which are well tested in both isolation and integration using appropriate data
-* 3: Application is well tested but does not balance isolation and integration tests, using only the data necessary to test the functionality
-* 2: Application makes use of tests, but the coverage is insufficient
-* 1: Application does not demonstrate use of TDD, or an insufficient number of tests.
-
-### 3. Encapsulation / Breaking Logic into Components
+### 2. Breaking Logic into Components
 
 * 4: Application always breaks concepts into classes and methods which encapsulate functionality.
 * 3: Application consistently breaks concepts into classes and methods which have appropriate scope and responsibilities (SRP).
 * 2: Application makes use of some classes, but the divisions or encapsulation are unclear.
 * 1: Application makes use of just a few huge methods to control the bulk of the functionality.
+
+### 3. Test-Driven Development
+
+* 4: Application is broken into components which are well tested in both isolation and integration using appropriate data
+* 3: Application is well tested but does not balance isolation and integration tests, using only the data necessary to test the functionality
+* 2: Application makes use of tests, but the coverage is insufficient
+* 1: Application does not demonstrate use of TDD, or an insufficient number of tests.
 
 ### 4. Functional Expectations
 

--- a/module1/projects/sorting_suite.markdown
+++ b/module1/projects/sorting_suite.markdown
@@ -347,26 +347,26 @@ SortingSuite::InsertionSort.new(array).sort.object_id == array.object_id
 
 The project will be assessed with the following guidelines:
 
-### 1. Fundamental Ruby & Style
+### 1. Ruby Sytnax & Style
 
 * 4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring
 * 3:  Application shows strong effort towards organization, content, and refactoring
 * 2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
 * 1:  Application generates syntax error or crashes during execution
 
-### 2. Test-Driven Development
-
-* 4: Application is broken into components which are well tested in both isolation and integration
-* 3: Application is well tested but does not balance isolation and integration tests, using only the data necessary to test the functionality
-* 2: Application makes some use of tests, but the coverage is insufficient
-* 1: Application does not demonstrate strong use of TDD
-
-### 3. Encapsulation / Breaking Logic into Components
+### 2. Breaking Logic into Components
 
 * 4: Application is expertly divided into logical components each with a clear, single responsibility
 * 3: Application effectively breaks logical components apart but breaks the principle of SRP
 * 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
 * 1: Application logic shows poor decomposition with too much logic mashed together
+
+### 3. Test-Driven Development
+
+* 4: Application is broken into components which are well tested in both isolation and integration
+* 3: Application is well tested but does not balance isolation and integration tests, using only the data necessary to test the functionality
+* 2: Application makes some use of tests, but the coverage is insufficient
+* 1: Application does not demonstrate strong use of TDD
 
 ### 4. Functional Expectations
 


### PR DESCRIPTION
@s-espinosa @mikedao 
Most rubrics had these three changes:
* Change Fundamental Ruby & Style to Ruby Syntax & Style to match General Rubric
* Remove Encapsulation from Encapsulation/Breaking Logic into Components to match General Rubric
* Changed order of sections ,flipping TDD/Encapsulation to match General Rubric

Some rubrics had the following change:
* Remove looping/recursion section  

Questions:  
* Battleship and Mastermind currently have REPL sections. Do you want them removed since they are not consistent with the General Rubric?  

* The Battleship rubric version that we used this mod had a section on Git. The one that I edited didn't have a git section. The General Rubric does not have a git section, but Success does. Do we want one? If so, which projects should we apply it to? 