### PR TITLE
Remove REPL section from Battleship and Mastermind & Add Version Control to wk 4-6 projects

### DIFF
--- a/module1/projects/b1_project_rubric_template.md
+++ b/module1/projects/b1_project_rubric_template.md
@@ -39,7 +39,7 @@ The project will be assessed with the following guidelines:
 
 ### 6. Debugging
 <!-- (only relevant for pairing) -->
-* 4: Student uses pry, `puts`, and error messages to ruthlessly get feedback from the system, and can use this feedback to fix errors.
+* 4: Student uses pry, `puts`, and error messages to get feedback from the system, and can use this feedback to fix errors.
 * 3: Student uses debugging tools like pry, or `puts`, but may need some help to identify issues.
 * 2: Student uses debugging tools only when prompted on multiple occassions.
 * 1: Student does not demonstrate that they are able to use debugging tools even when prompted.
@@ -51,4 +51,13 @@ The output from `rake sanitation:all` shows...
 * 4: Zero complaints
 * 3: Five or fewer complaints
 * 2: Six to ten complaints
-* 1: More than ten complaints
+* 1: More than ten complaints  
+
+### 8. Version Control  
+<!--  (doesn't apply to all projects, but a good spot for project-specific rubric requirements) -->  
+* 4: Student demonstrates strong git workflow, utilizing pull requests for communication and feedback  
+* 3: Student utilizess git workflow essentials on an ongoing basis to track project progress both locally and remotely
+* 2: Student adds and commits infrequently and pushes project to GitHub  
+* 1: Student makes an initial commit and pushes project to GitHub  
+
+

--- a/module1/projects/b1_project_rubric_template.md
+++ b/module1/projects/b1_project_rubric_template.md
@@ -55,9 +55,7 @@ The output from `rake sanitation:all` shows...
 
 ### 8. Version Control  
 <!--  (doesn't apply to all projects, but a good spot for project-specific rubric requirements) -->  
-* 4: Student demonstrates strong git workflow, utilizing pull requests for communication and feedback  
-* 3: Student utilizess git workflow essentials on an ongoing basis to track project progress both locally and remotely
+* 4: Student demonstrates strong git workflow, commits frequently to document progress, uses commits to identify added functionality, and utilizes pull requests for communication and feedback  
+* 3: Student utilizes git workflow essentials, committing frequently to document progress
 * 2: Student adds and commits infrequently and pushes project to GitHub  
 * 1: Student makes an initial commit and pushes project to GitHub  
-
-

--- a/module1/projects/battleship.markdown
+++ b/module1/projects/battleship.markdown
@@ -245,7 +245,7 @@ Wrap your code into a Ruby gem and publish it on Rubygems.org with a name like
 
 The project will be assessed with the following rubric:
 
-### 1. Fundamental Ruby & Style
+### 1. Ruby Sytnax & Style
 
 * 4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring
 * 3:  Application shows strong effort towards organization, content, and refactoring
@@ -254,8 +254,8 @@ The project will be assessed with the following rubric:
 
 ### 2. Breaking Logic into Components
 
-* 4: Application is expertly divided into logical components such that individual pieces could be reused or replaced without difficulty
-* 3: Application effectively breaks logical components apart with clear intent and usage
+* 4: Application is expertly divided into logical components each with a clear, single responsibility
+* 3: Application effectively breaks logical components apart but breaks the principle of SRP
 * 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
 * 1: Application logic shows poor decomposition with too much logic mashed together
 
@@ -273,3 +273,9 @@ The project will be assessed with the following rubric:
 * 2: Application runs, but does not work properly, or does not meet specifications.
 * 1: Application does not run, crashes on start.
 
+### 5. Version Control  
+ 
+* 4: Student demonstrates strong git workflow, commits frequently to document progress, uses commits to identify added functionality, and utilizes pull requests for communication and feedback  
+* 3: Student utilizes git workflow essentials, committing frequently to document progress
+* 2: Student adds and commits infrequently and pushes project to GitHub  
+* 1: Student makes an initial commit and pushes project to GitHub  

--- a/module1/projects/battleship.markdown
+++ b/module1/projects/battleship.markdown
@@ -273,9 +273,3 @@ The project will be assessed with the following rubric:
 * 2: Application runs, but does not work properly, or does not meet specifications.
 * 1: Application does not run, crashes on start.
 
-### 6. REPL Interface
-
-* 4: Application's REPL goes above and beyond expectations to improve the gameplay
-* 3: Application's REPL is clear and pleasant to use
-* 2: Application's REPL has some inconsistencies or rough edges
-* 1: Application's REPL has enough problems as to make play difficult

--- a/module1/projects/black_thursday.markdown
+++ b/module1/projects/black_thursday.markdown
@@ -56,7 +56,7 @@ Evaluation Rubric
 
 The project will be assessed with the following guidelines:
 
-### 1. Fundamental Ruby & Style
+### 1. Ruby Syntax & Style
 
 *   4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring
 *   3:  Application shows strong effort towards organization, content, and refactoring
@@ -91,4 +91,12 @@ The output from `rake sanitation:all` shows...
 *   4: Zero complaints
 *   3: Five or fewer complaints
 *   2: Six to ten complaints
-*   1: More than ten complaints
+*   1: More than ten complaints  
+
+### 5. Version Control  
+<!--  (doesn't apply to all projects, but a good spot for project-specific rubric requirements) -->  
+* 4: Student demonstrates strong git workflow, commits frequently to document progress, uses commits to identify added functionality, and utilizes pull requests for communication and feedback  
+* 3: Student utilizes git workflow essentials, committing frequently to document progress
+* 2: Student adds and commits infrequently and pushes project to GitHub  
+* 1: Student makes an initial commit and pushes project to GitHub  
+

--- a/module1/projects/flashcards.markdown
+++ b/module1/projects/flashcards.markdown
@@ -206,19 +206,19 @@ Build in hint functionality. If a user enters "hint" when it's time to guess, th
 
 The project will be assessed with the following guidelines:
 
-### 1. Fundamental Ruby & Style
+### 1. Ruby Syntax & Style
 
 * 4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring.
 * 3:  Application shows strong effort towards organization, content, and refactoring.
 * 2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring.
 * 1:  Application generates syntax error or crashes during execution.
 
-### 2. Enumerable & Collections
+### 2. Breaking Logic into Components
 
-* 4: Application consistently makes use of the best-choice Enumerable methods
-* 3: Application demonstrates comfortable use of appropriate Enumerable methods
-* 2: Application demonstrates functional knowledge of Enumerable but only uses the most basic techniques
-* 1: Application demonstrates deficiencies with Enumerable and struggles with collections
+* 4: Application is expertly divided into logical components each with a clear, single responsibility.
+* 3: Application effectively breaks logical components apart but breaks the principle of SRP.
+* 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear.
+* 1: Application logic shows poor decomposition with too much logic mashed together.
 
 ### 3. Test-Driven Development
 
@@ -226,13 +226,6 @@ The project will be assessed with the following guidelines:
 * 3: Application is well tested but does not balance isolation and integration tests, using only the data necessary to test the functionality.
 * 2: Application makes some use of tests, but the coverage is insufficient given projet requirements.
 * 1: Application does not demonstrate strong use of TDD.
-
-### 4. Encapsulation / Breaking Logic into Components
-
-* 4: Application is expertly divided into logical components each with a clear, single responsibility.
-* 3: Application effectively breaks logical components apart but breaks the principle of SRP.
-* 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear.
-* 1: Application logic shows poor decomposition with too much logic mashed together.
 
 ### 5. Functional Expectations
 

--- a/module1/projects/headcount.markdown
+++ b/module1/projects/headcount.markdown
@@ -156,7 +156,7 @@ The test harness for Headcount is [here](https://github.com/turingschool-example
 
 The project will be assessed with the following guidelines:
 
-### 1. Fundamental Ruby & Style
+### 1. Ruby Syntax & Style
 
 * 4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring
 * 3:  Application shows strong effort towards organization, content, and refactoring
@@ -191,7 +191,15 @@ The output from `rake sanitation:all` shows...
 * 4: Zero complaints
 * 3: Five or fewer complaints
 * 2: Six to ten complaints
-* 1: More than ten complaints
+* 1: More than ten complaints  
+
+### 6. Version Control  
+ 
+* 4: Student demonstrates strong git workflow, commits frequently to document progress, uses commits to identify added functionality, and utilizes pull requests for communication and feedback  
+* 3: Student utilizes git workflow essentials, committing frequently to document progress
+* 2: Student adds and commits infrequently and pushes project to GitHub  
+* 1: Student makes an initial commit and pushes project to GitHub  
+
 
 ## Appendix - Data Sources
 

--- a/module1/projects/http_yeah_you_know_me.markdown
+++ b/module1/projects/http_yeah_you_know_me.markdown
@@ -413,9 +413,17 @@ The project will be assessed with the following rubric:
 * 4: Application implements all five iterations and at least one extension
 * 3: Application implements iterations 0 - 4
 * 2: Application implements iterations 0 - 3
-* 1: Application implements through interation 2 or less
+* 1: Application implements through interation 2 or less  
 
-**Echo/Foxtrot Note:** Requirements listed are for *Foxtrot* pairs -- Echo requirements are shifted by 1 additional iteration -- So a 3 for Echo requires completing Iterations 0-5
+**Echo/Foxtrot Note:** Requirements listed are for *Foxtrot* pairs -- Echo requirements are shifted by 1 additional iteration -- So a 3 for Echo requires completing Iterations 0-5  
+
+### 5. Version Control  
+ 
+* 4: Student demonstrates strong git workflow, commits frequently to document progress, uses commits to identify added functionality, and utilizes pull requests for communication and feedback  
+* 3: Student utilizes git workflow essentials, committing frequently to document progress
+* 2: Student adds and commits infrequently and pushes project to GitHub  
+* 1: Student makes an initial commit and pushes project to GitHub  
+
 
 ## Addendum Content
 

--- a/module1/projects/hyde/rubric.markdown
+++ b/module1/projects/hyde/rubric.markdown
@@ -8,7 +8,29 @@ layout: page
 
 The project will be assessed with the following guidelines:
 
-### 1. Functional Expectations
+### 1. Ruby Syntax & Style
+
+* 4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring. Code is consistently clear and makes excellent use of common ruby patterns and idioms.
+* 3:  Application shows strong effort towards organization and refactoring but still has some long or difficult-to-read methods. Some ruby idioms or patterns could still be applied more consistently.
+* 2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
+* 1:  Application generates syntax error or crashes during execution
+
+### 2. Breaking Logic into Components
+
+* 4: Application is expertly divided into logical components each with a clear, single responsibility
+* 3: Application effectively breaks logical components apart but breaks the principle of SRP
+* 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
+* 1: Application logic shows poor decomposition with too much logic mashed together
+
+
+### 3. Test-Driven Development
+
+* 4: Application is broken into components which are well tested in both isolation and integration using appropriate data
+* 3: Application is well tested but does not balance isolation and integration tests, using only the data necessary to test the functionality
+* 2: Application makes some use of tests, but the coverage is insufficient
+* 1: Application does not demonstrate strong use of TDD
+
+### 4. Functional Expectations
 
 * 4: Application completes all required iterations and adds comparable feature(s) of its own design
 * 3: Application completes all features in Iterations 0-5
@@ -16,31 +38,3 @@ The project will be assessed with the following guidelines:
 * 1: Application does not complete iterations 0-3
 
 **Echo/Foxtrot Note:** Requirements listed are for *Foxtrot* pairs -- Echo requirements are shifted by 1 additional iteration -- So a 3 for Echo requires completing Iterations 0-6
-
-### 2. Test-Driven Development
-
-* 4: Application is broken into components which are well tested in both isolation and integration using appropriate data
-* 3: Application is well tested but does not balance isolation and integration tests, using only the data necessary to test the functionality
-* 2: Application makes some use of tests, but the coverage is insufficient
-* 1: Application does not demonstrate strong use of TDD
-
-### 3. Encapsulation / Breaking Logic into Components
-
-* 4: Application is expertly divided into logical components each with a clear, single responsibility
-* 3: Application effectively breaks logical components apart but suffers from some repetition or lack of consistency between components.
-* 2: Application shows some effort to break logic into components, but the divisions are inconsistent or unclear
-* 1: Application logic shows poor decomposition with too much logic mashed together
-
-### 4. Fundamental Ruby & Style
-
-* 4:  Application demonstrates excellent knowledge of Ruby syntax, style, and refactoring. Code is consistently clear and makes excellent use of common ruby patterns and idioms.
-* 3:  Application shows strong effort towards organization and refactoring but still has some long or difficult-to-read methods. Some ruby idioms or patterns could still be applied more consistently.
-* 2:  Application runs but the code has long methods, unnecessary or poorly named variables, and needs significant refactoring
-* 1:  Application generates syntax error or crashes during execution
-
-### 5. Enumerable & Collections
-
-* 4: Application consistently makes use of the best-choice Enumerable methods
-* 3: Application demonstrates comfortable use of appropriate Enumerable methods
-* 2: Application demonstrates functional knowledge of Enumerable but only uses the most basic techniques
-* 1: Application demonstrates deficiencies with Enumerable and struggles with collections

--- a/module1/projects/mastermind.markdown
+++ b/module1/projects/mastermind.markdown
@@ -163,10 +163,3 @@ The project will be assessed with the following rubric:
 *   3: Application meets all requirements as laid out per the specification.
 *   2: Application runs, but does not work properly, or does not meet specifications.
 *   1: Application does not run, crashes on start.
-
-### 6. REPL Interface and Game Functionality
-
-*   4: Application's REPL goes above and beyond expectations and application includes one or more extensions
-*   3: Application's REPL is clear and pleasant to use and application fulfills base expectations from the project spec
-*   2: Application's REPL has inconsistencies and/or there are errors in base gameplay
-*   1: Application's REPL has several issues or application fails to run


### PR DESCRIPTION
REPL section removed.  
Any thoughts on the following?  @s-espinosa @mikedao 
The Battleship rubric version that we used this mod had a section on Git. The one that I edited didn't have a git section. The General Rubric does not have a git section, but Success does. Do we want one? If so, which projects should we apply it to? 