### PR TITLE
Fix Sinatra Title in header materials

### DIFF
--- a/module2/lessons/crud_in_sinatra_workshop.md
+++ b/module2/lessons/crud_in_sinatra_workshop.md
@@ -1,5 +1,5 @@
 ---
-title: CRUD in Sinatra Workshop: Robot World
+title: CRUD in Sinatra Workshop - Robot World
 length: 120
 tags: crud, sinatra
 ---


### PR DESCRIPTION
Jekyll doesn't seem to like the colon in the headers.