### PR TITLE
Remove link to lesson plans from index

### DIFF
--- a/module2/index.md
+++ b/module2/index.md
@@ -44,7 +44,6 @@ subheading: Web Applications with Ruby
 ### Important Links
 
 * [__Mod 2 Success__](./success)
-* [__Mod 2 Lesson Plans__](lessons)
 * [__Mod 2 Portfolio Requirements__](./portfolios)
 * [__Mod 2 Professional Development Curriculum__](https://github.com/turingschool/career-development-curriculum/tree/master/module_two)
 


### PR DESCRIPTION
* Remove redundant link since lesson plans are linked from weekly outlines.