### PR TITLE
Enforce https use for backend.turing.io

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: "Back-End Engineering Curriculum - Turing School of Software and Design"
 description: "Open source curriculum for the Turing School of Software and Design's back end engineering program."
-url: "http://backend.turing.io/"
+url: "https://backend.turing.io/"
 
 baseurl: ''
 permalink: /:title

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,7 +17,7 @@
 <link rel="icon" type="image/png" sizes="32x32" href="assets/favicons/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="96x96" href="assets/favicons/favicon-96x96.png">
 <link rel="icon" type="image/png" sizes="16x16" href="assets/favicons/favicon-16x16.png">
-<link rel="shortcut icon" type="image/png" href="{{ site.url }}assets/favicons/favicon-16x16.png">
+<link rel="shortcut icon" type="image/png" href="assets/favicons/favicon-16x16.png">
 <link rel="manifest" href="assets/favicons/manifest.json">
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
@@ -37,7 +37,7 @@
 {% endif %}
 
 <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,700' rel='stylesheet' type='text/css'>
-<link rel="stylesheet" type="text/css" href='{{ site.url }}/stylesheets/reset.css'>
-<link rel="stylesheet" type="text/css" href='{{ site.url }}/stylesheets/styles-2017121801.css'>
+<link rel="stylesheet" type="text/css" href='stylesheets/reset.css'>
+<link rel="stylesheet" type="text/css" href='stylesheets/styles-2017121801.css'>
 <script src="https://code.jquery.com/jquery-3.1.1.min.js" integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
 <script type="text/javascript" src="/assets/javascript/navigation.js"></script>


### PR DESCRIPTION
We should be forcing the use of https for the backend.turing.io site. 

We can do that following the directions here: https://help.github.com/en/articles/securing-your-github-pages-site-with-https

This came about from a student notifying me that our styling did not work when viewing our site via https://backend.turing.io. This was due to using absolute links to our stylesheets. I have replaced with relative links and once merged will enforce https via the above instructions