### PR TITLE
Change home button to link back to main Turing site

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,11 +1,12 @@
 <nav role="navigation">
   <ul class="nav-links">
     <li>
-      <a href="/" class="home-logo-link">
+      <a href="https://turing.io/" class="home-logo-link">
         <img src="/assets/icons/TuringSchool_LogoMark_Gray.png"
          alt="Turing School of Software and Design logo">
       </a>
     </li>
+    <li class="uppercase"><a href="/">BE Home</a></li>
     <li class="uppercase"><a href="/module1">Module 1</a></li>
     <li class="uppercase"><a href="/module2">Module 2</a></li>
     <li class="uppercase"><a href="/module3">Module 3</a></li>

--- a/_sass/sidebar.scss
+++ b/_sass/sidebar.scss
@@ -8,7 +8,7 @@ nav {
 
 .nav-links {
   display: grid;
-  grid-template-columns: auto 100px 100px 100px 100px 215px;
+  grid-template-columns: auto 100px 100px 100px 100px 100px 215px;
   grid-template-rows: 120px;
   align-items: center;
   justify-items: center;


### PR DESCRIPTION
# Changes

* Adjusted link from logo in nav to point back to the main Turing site.

# Reason (from Lindsey)

* Due to some technical keyword weirdness with the our Google Grants ads, a lot of people are ending up on the curriculum site after searching coding related terms and they could be potential students so I just want to make sure they have an easy link back to the site where they can sign up for TC and start and app.