### PR TITLE
Remove head matter to keep Jekyll/Liquid from trying to parse Ember

### DIFF
--- a/module4/lessons/archive/ember_routing.markdown
+++ b/module4/lessons/archive/ember_routing.markdown
@@ -1,3 +1,4 @@
+<!--
 ---
 layout: page
 title: Ember Routing
@@ -5,6 +6,7 @@ length: 90
 tags: javascript, ember
 status: deprecated
 ---
+-->
 
 ## Lecture
 

--- a/module4/lessons/archive/getting-bartleby-started.md
+++ b/module4/lessons/archive/getting-bartleby-started.md
@@ -1,8 +1,10 @@
+<!--
 ---
 layout: page
 title: Fecho - Bartleby
 subheading: Getting Started
 ---
+-->
 
 ## Basic Setup and Installation
 

--- a/module4/lessons/archive/mvc_in_ember.markdown
+++ b/module4/lessons/archive/mvc_in_ember.markdown
@@ -1,3 +1,4 @@
+<!--
 ---
 layout: page
 title: MVC in Ember
@@ -5,6 +6,7 @@ length: 120
 tags: javascript, ember
 status: draft
 ---
+-->
 
 ## Learning Goals
 

--- a/module4/lessons/archive/super-introduction-to-ember.markdown
+++ b/module4/lessons/archive/super-introduction-to-ember.markdown
@@ -1,7 +1,9 @@
+<!--
 ---
 layout: page
 title: Super Intro to Ember
 ---
+-->
 
 ## Prerequisites
 


### PR DESCRIPTION
The Liquid templating language that Jekyll uses and Ember use similar characters to delimit their code from other code. This was generating errors when you ran `jekyll build` and `jekyll serve`. In the future we could escape those snippets with `{% raw %}` and `{% endraw %}`, but since all of our Ember pages are currently in our archives I commented out the head matter that tells Liquid to try to parse a page.