### PR TITLE
Fix broken links and add typo correction 'agnostic'

### DIFF
--- a/module3/lessons/building_an_api.md
+++ b/module3/lessons/building_an_api.md
@@ -41,7 +41,7 @@ In the end, though, as developers we have a choice to make around our developmen
 
 #### RESTful Wrap-Up
 
-REST is language-agnostics, and is a standard we should continue to build, but we ARE allowed some flexibility.
+REST is language-agnostic, and is a standard we should continue to build, but we ARE allowed some flexibility.
 
 ---
 


### PR DESCRIPTION
Sending over a friendly PR for two requested updates:

* Main correction: there are two links to examples of JSON. The first does not seem to be appropriate (doesn't navigate to JSON specifically), and the second does not work (receive a response error)
* Minor typo update ('agnostic' rather than 'agnostics')

Are you able to fix the faulty links?