### PR TITLE
Remove RuboCop requirement

### DIFF
--- a/module3/projects/viewing_party/requirements.md
+++ b/module3/projects/viewing_party/requirements.md
@@ -8,7 +8,6 @@ type: project
 ## Viewing Party Requirements
 
 ### Requirement Overview
-- Use RuboCop in project to enforce style guide
 - Deploy to Heroku
 - Use TravisCI for Continuous Integration
 - Consume [The Movie DB API](https://developers.themoviedb.org/3/getting-started/introduction)
@@ -37,6 +36,7 @@ As an EXTENSION (once ALL other MVP work is complete):
 
 ### Exploration Topic Ideas
 
+- Use RuboCop in project to enforce style guide
 - Additional API consumption
 - ActionCable
 - ActionMailer

--- a/module3/projects/viewing_party/rubric.md
+++ b/module3/projects/viewing_party/rubric.md
@@ -21,7 +21,7 @@ title: Viewing Party Project Rubric
 
 ### Code Quality
 
-Project should use [RuboCop](https://github.com/rubocop-hq/rubocop) to measure code quality.
+Project may use [RuboCop](https://github.com/rubocop-hq/rubocop) to measure code quality.
 
 - **4:** Team can demonstrate how API consumption portions of the project demonstrate all of the four pillars listed below and RuboCop has no complaints. Team can identify areas where code can be refactored and how they may have created technical debt.
 - **3:** Team can demonstrate how API consumption portions of the project demonstrate 2 of pillars listed below, and RuboCop complains about 3 or less violations. Team can identify areas where code can be refactored.


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

Changes Rubocop wording for viewing party lite

### Why are we making this update?

Rubocop is no longer a requirement for viewing party
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

n/a

### What questions do you have/what do you want feedback on? (optional)

n/a
