### PR TITLE
Remove leftover reference to Travis CI

### DIFF
--- a/module3/projects/consultancy/development.md
+++ b/module3/projects/consultancy/development.md
@@ -42,7 +42,7 @@ Day 1:
   - Rough implementation and testing of the front-end, mocking out responses from back-end; no authentication expected yet
   - Rough implementation and testing of back-end API, mocking requests from front-end
   - Initial structure of each Service (not necessarily working API calls)
-  - Travis-CI/Circle-CI and Deployment to Heroku for both FE/BE repositories
+  - Circle-CI and Deployment to Heroku for both FE/BE repositories
 
 #### Sprint 2: Primary Development
 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

Remove leftover reference to Travis CI

### Why are we making this update?

We are no longer recommending Travis CI to students due to pricing changes that make this no longer free.
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

