### PR TITLE
Juliet: Update learning goals after lesson planning discussion with Alex

### DIFF
--- a/module3/lessons/customizing_json.md
+++ b/module3/lessons/customizing_json.md
@@ -6,9 +6,9 @@ tags: json, javascript, rails, ruby, api
 
 ## Learning Goals
 
+* Articulate what a serializer is and how to create one in a Rails application.
 * Understand the purpose of serializers and how they support OOP Principles
 * Understand what constitutes presentation logic in the context of serving a JSON API and why formatting in the model is not the right place
-* Articulate what a serializer is and how to create one in a Rails application. 
 
 ## Warmup
 

--- a/module3/lessons/customizing_json.md
+++ b/module3/lessons/customizing_json.md
@@ -6,8 +6,9 @@ tags: json, javascript, rails, ruby, api
 
 ## Learning Goals
 
-* Generate and customize Rails Serializers
+* Understand the purpose of serializers and how they support OOP Principles
 * Understand what constitutes presentation logic in the context of serving a JSON API and why formatting in the model is not the right place
+* Articulate what a serializer is and how to create one in a Rails application. 
 
 ## Warmup
 
@@ -198,7 +199,6 @@ So we have our responses from our server, but it isn’t JSON API 1.0 And it has
       "id": "1",
       "type": "store",
       "attributes": {
-        "id": 1,
         "name": "Toy, Steuber and Schinner",
         "num_books": 8
       },


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

This PR covers edits to the learning goals for the Customizing JSON in your API lesson. It also deletes an extra attribute in the store JSON output (ID was listed both in the root level of a store, as well as under attributes. JSON API specs dictate it's just in the root). 

### Why are we making this update?

After discussing my lesson plan with Alex, we noticed the learning goals for the Customizing JSON lesson didn't quite capture some important themes around connections to OOP, MVC,etc. with a wide net. We also updated some language to distinguish from learning goals vs. activities to reach those learning goals. 
  
### Type of update

- [ ] Minor update/fix -- no review requested
- [X] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

Hypothesized outcomes: Students are able to draw connections to larger themes from the narrow context of a serializer more quickly (i.e. in the course of the lesson) rather than later in the mod. Students will be able to transfer background knowledge about MVC design pattern and make connections about rules that hold for different "types" of presentation layers (views vs. serializers).

MoS: Student surveys, rails engine check ins (what do your serializers look like? What approach are you using?), rails engine evals

### What questions do you have/what do you want feedback on? (optional)

Please let me know what you think about the language in the learning goals and if this change covers wider themes!
