### PR TITLE
Adds resume requirement to consultancy, removes references to Travis CI

### DIFF
--- a/module3/projects/consultancy/evaluation/instructor_tracker.md
+++ b/module3/projects/consultancy/evaluation/instructor_tracker.md
@@ -105,7 +105,7 @@ __When the above criteria is met, here are additional points to achieve a 4__
 
 - [ ] Optimization techniques implemented in all repos
 
-- Travis-CI deploys to Heroku
+- CircleCI deploys to Heroku
     - [ ] Frontend
     - [ ] Rails Back End
 

--- a/module3/projects/consultancy/evaluation/presentation_documentation.md
+++ b/module3/projects/consultancy/evaluation/presentation_documentation.md
@@ -37,13 +37,19 @@ Each Repo's README meets the following:
 - [ ] discusses the purpose of its purpose (how it fits into the project SOA)
 - [ ] discusses how to install and test the repo
 
-Fronten README:
+Frontend README:
 - [ ] has screenshots
 - [ ] discusses OAuth
 
 Rails backend README:
 - [ ] includes database schema
 - [ ] each endpoint is documented with example request & response
+
+---
+
+Resume
+
+Each group member should create a version of their current resume that lists Consultancy in the 'projects' section and highlights their work using appropriate technical terminology. 
 
 ---
 

--- a/module3/projects/consultancy/evaluation/technical_quality.md
+++ b/module3/projects/consultancy/evaluation/technical_quality.md
@@ -37,7 +37,7 @@ Each Repo meets the following:
     - [ ] Frontend
     - [ ] Rails Backend
 
-- Travis CI is set up
+- CircleCI is set up
     - [ ] Frontend
     - [ ] Rails Backend
 
@@ -62,7 +62,7 @@ __When the above criteria is met, here are additional points to achieve a 4__
     - [ ] Frontend
     - [ ] Rails Backend
 
-- Travis-CI deploys to Heroku
+- CircleCI deploys to Heroku
     - [ ] Frontend
     - [ ] Rails Backend
 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

We are adding a requirement to the Consultancy project: each group member will add the project to their resume.

### Why are we making this update?

1) Career dev request: several students from recent cohorts have not included Consultancy projects on their resumes.
2) We hypothesize that this would be another valuable opportunity for students to practice describing their contributions and use technical terminology.
  
### Type of update

- [ ] Minor update/fix -- no review requested
- [x] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

We will communicate with the career dev team over the course of the next few innings, to see if more people are showing off their work on Consultancy.

### What questions do you have/what do you want feedback on? (optional)


