### PR TITLE
Replaces Hogwarts with Cabot Cove College repo link

### DIFF
--- a/module2/exercises.md
+++ b/module2/exercises.md
@@ -21,7 +21,7 @@ layout: page
 - [Routes and controllers](https://github.com/turingschool/challenges/blob/master/routes_controllers_rails.markdown).
 
 ## Independent Challenge Practices
-- [Hogwarts](https://github.com/turingschool-examples/bloody_hogwarts) (Week 2)
+- [Cabot Cove College](https://github.com/turingschool-examples/cabot-cove-college-b2) (Week 2)
 - [Apollo 14](https://github.com/turingschool-projects/apollo_14) (Week 2)
 - [Vending Machine Tracker](https://github.com/turingschool-examples/vending-machine-tracker/tree/master) (Week 4)
 - [The Final Rose](https://github.com/turingschool-examples/the_final_rose) - Longer than an actual in class challenge, but could be good preparation before Week 4 challenge, or prep for the final. 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

Removes **Hogwarts** as practice repo for week 2 practice assessment, replaces with link for **Cabot Cove College**

### Why are we making this update?

Continuing in the effort to promote only inclusive references in our curriculum; also, R.I.P Angela Lansbury

### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

n/a
### What questions do you have/what do you want feedback on? (optional)

n/a