### PR TITLE
Changes API links from heroku to fly.dev

### DIFF
--- a/module2/lessons/api_consumption_in_ruby.md
+++ b/module2/lessons/api_consumption_in_ruby.md
@@ -55,12 +55,12 @@ require 'json'
 require 'pry'
 ```
 
-We are going to use HTTParty in order to reach out to our API and get the results. We look at the documentation for the Ghibli Films API, `https://ghibliapi.herokuapp.com/#tag/Films` and we see that the endpoint we have to hit is `https://ghibliapi.herokuapp.com/films`
+We are going to use HTTParty in order to reach out to our API and get the results. We look at the documentation for the Ghibli Films API, `https://ghibliapi.fly.dev/#tag/Films` and we see that the endpoint we have to hit is `https://ghibliapi.fly.dev/films`
 
 The basic syntax for how we can get a response from an API is `HTTParty.get()`, where we pass the URL for the endpoint as an argument as a string.
 
 ```
-response = HTTParty.get("https://ghibliapi.herokuapp.com/films")
+response = HTTParty.get("https://ghibliapi.fly.dev/films")
 ```
 
 The get method from HTTParty returns us a special response object. Let's throw a binding.pry in there and see what we get.
@@ -79,17 +79,17 @@ The get method from HTTParty returns us a special response object. Let's throw a
   "running_time"=>"124",
   "rt_score"=>"95",
   "people"=>
-   ["https://ghibliapi.herokuapp.com/people/598f7048-74ff-41e0-92ef-87dc1ad980a9",
-    "https://ghibliapi.herokuapp.com/people/fe93adf2-2f3a-4ec4-9f68-5422f1b87c01",
-    "https://ghibliapi.herokuapp.com/people/3bc0b41e-3569-4d20-ae73-2da329bf0786",
-    "https://ghibliapi.herokuapp.com/people/40c005ce-3725-4f15-8409-3e1b1b14b583",
-    "https://ghibliapi.herokuapp.com/people/5c83c12a-62d5-4e92-8672-33ac76ae1fa0",
-    "https://ghibliapi.herokuapp.com/people/e08880d0-6938-44f3-b179-81947e7873fc",
-    "https://ghibliapi.herokuapp.com/people/2a1dad70-802a-459d-8cc2-4ebd8821248b"],
-  "species"=>["https://ghibliapi.herokuapp.com/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"],
-  "locations"=>["https://ghibliapi.herokuapp.com/locations/"],
-  "vehicles"=>["https://ghibliapi.herokuapp.com/vehicles/4e09b023-f650-4747-9ab9-eacf14540cfb"],
-  "url"=>"https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"},
+   ["https://ghibliapi.fly.dev/people/598f7048-74ff-41e0-92ef-87dc1ad980a9",
+    "https://ghibliapi.fly.dev/people/fe93adf2-2f3a-4ec4-9f68-5422f1b87c01",
+    "https://ghibliapi.fly.dev/people/3bc0b41e-3569-4d20-ae73-2da329bf0786",
+    "https://ghibliapi.fly.dev/people/40c005ce-3725-4f15-8409-3e1b1b14b583",
+    "https://ghibliapi.fly.dev/people/5c83c12a-62d5-4e92-8672-33ac76ae1fa0",
+    "https://ghibliapi.fly.dev/people/e08880d0-6938-44f3-b179-81947e7873fc",
+    "https://ghibliapi.fly.dev/people/2a1dad70-802a-459d-8cc2-4ebd8821248b"],
+  "species"=>["https://ghibliapi.fly.dev/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"],
+  "locations"=>["https://ghibliapi.fly.dev/locations/"],
+  "vehicles"=>["https://ghibliapi.fly.dev/vehicles/4e09b023-f650-4747-9ab9-eacf14540cfb"],
+  "url"=>"https://ghibliapi.fly.dev/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"},
 ```
 This looks like it's just JSON object but it's a response object. We can verify this by calling the class method on it. HTTParty is designed to let us see the response's body if we just look at the object.
 
@@ -98,7 +98,7 @@ There's a lot of information in there, but we are really only concerned with the
 So we look at what `response.body` will return.
 
 ```
-"[\n  {\n    \"id\": \"2baf70d1-42bb-4437-b551-e5fed5a87abe\",\n    \"title\": \"Castle in the Sky\",\n    \"description\": \"The orphan Sheeta inherited a mysterious crystal that links her to the mythical sky-kingdom of Laputa. With the help of resourceful Pazu and a rollicking band of sky pirates, she makes her way to the ruins of the once-great civilization. Sheeta and Pazu must outwit the evil Muska, who plans to use Laputa's science to make himself ruler of the world.\",\n    \"director\": \"Hayao Miyazaki\",\n    \"producer\": \"Isao Takahata\",\n    \"release_date\": \"1986\",\n    \"rt_score\": \"95\",\n    \"people\": [\n      \"https://ghibliapi.herokuapp.com/people/\"\n    ],\n    \"species\": [\n      \"https://ghibliapi.herokuapp.com/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2\"\n    ],\n    \"locations\": [\n      \"https://ghibliapi.herokuapp.com/locations/\"\n    ],\n    \"vehicles\": [\n      \"https://ghibliapi.herokuapp.com/vehicles/\"\n    ],\n    \"url\": \"https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe\"\n  },\n  {\n    \"id\": \"12cfb892-aac0-4c5b-94af-521852e46d6a\",\n    \"title\": \"Grave of the Fireflies\",\n    \"description\": \"In the latter part of World War II, a boy and his sister, orphaned when their mother is killed in the firebombing of Tokyo, are left to survive on their own in what remains of civilian life in Japan. The plot follows this boy and his sister as they do their best to survive in the Japanese countryside, battling hunger, prejudice, and pride in their own quiet, personal battle.\",\n    \"director\": \"Isao Takahata\",\n    \"producer\": \"Toru Hara\",\n    \"release_date\": \"1988\",\n    \"rt_score\": \"97\",\n    \"people\": [\n      \"https://ghibliapi.herokuapp.com/people/\"\n    ],\n    \"species\": [\n      \"https://ghibliapi.herokuapp.com/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2\"\n    ],\n    \"locations\": [\n      \"https://ghibliapi.herokuapp.com/locations/\"\n    ],\n    \"vehicles\": [\n      \"https://ghibliapi.herokuapp.com/vehicles/\"\n    ],\n    \"url\": \"https://ghibliapi.herokuapp.com/films/12cfb892-aac0-4c5b-94af-521852e46d6a\"\n  },\n  {\n    \"id\": \"58611129-2dbc-4a81-a72f-77ddfc1b1b49\",\n    \"title\": \"My Neighbor Totoro\",\n    \"description\": \"Two sisters move to the country with their father in order to be closer to their hospitalized mother, and discover the surrounding trees are inhabited by Totoros, magical spirits of the forest. When the youngest runs away from home, the older sister seeks help from the spirits to find her.\",\n    \"director\": \"Hayao Miyazaki\",\n    \"producer\": \"Hayao Miyazaki\",\n    \"release_date\": \"1988\",\n    \"rt_score\": \"93\",\n    \"people\": [\n      \"https://ghibliapi.herokuapp.com/people/986faac6-67e3-4fb8-a9ee-bad077c2e7fe\",\n      \"https://ghibliapi.herokuapp.com/people/d5df3c04-f355-4038-833c-83bd3502b6b9\",\n      \"https://ghibliapi.herokuapp.com/people/3031caa8-eb1a-41c6-ab93-dd091b541e11\",\n
+"[\n  {\n    \"id\": \"2baf70d1-42bb-4437-b551-e5fed5a87abe\",\n    \"title\": \"Castle in the Sky\",\n    \"description\": \"The orphan Sheeta inherited a mysterious crystal that links her to the mythical sky-kingdom of Laputa. With the help of resourceful Pazu and a rollicking band of sky pirates, she makes her way to the ruins of the once-great civilization. Sheeta and Pazu must outwit the evil Muska, who plans to use Laputa's science to make himself ruler of the world.\",\n    \"director\": \"Hayao Miyazaki\",\n    \"producer\": \"Isao Takahata\",\n    \"release_date\": \"1986\",\n    \"rt_score\": \"95\",\n    \"people\": [\n      \"https://ghibliapi.fly.dev/people/\"\n    ],\n    \"species\": [\n      \"https://ghibliapi.fly.dev/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2\"\n    ],\n    \"locations\": [\n      \"https://ghibliapi.fly.dev/locations/\"\n    ],\n    \"vehicles\": [\n      \"https://ghibliapi.fly.dev/vehicles/\"\n    ],\n    \"url\": \"https://ghibliapi.fly.dev/films/2baf70d1-42bb-4437-b551-e5fed5a87abe\"\n  },\n  {\n    \"id\": \"12cfb892-aac0-4c5b-94af-521852e46d6a\",\n    \"title\": \"Grave of the Fireflies\",\n    \"description\": \"In the latter part of World War II, a boy and his sister, orphaned when their mother is killed in the firebombing of Tokyo, are left to survive on their own in what remains of civilian life in Japan. The plot follows this boy and his sister as they do their best to survive in the Japanese countryside, battling hunger, prejudice, and pride in their own quiet, personal battle.\",\n    \"director\": \"Isao Takahata\",\n    \"producer\": \"Toru Hara\",\n    \"release_date\": \"1988\",\n    \"rt_score\": \"97\",\n    \"people\": [\n      \"https://ghibliapi.fly.dev/people/\"\n    ],\n    \"species\": [\n      \"https://ghibliapi.fly.dev/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2\"\n    ],\n    \"locations\": [\n      \"https://ghibliapi.fly.dev/locations/\"\n    ],\n    \"vehicles\": [\n      \"https://ghibliapi.fly.dev/vehicles/\"\n    ],\n    \"url\": \"https://ghibliapi.fly.dev/films/12cfb892-aac0-4c5b-94af-521852e46d6a\"\n  },\n  {\n    \"id\": \"58611129-2dbc-4a81-a72f-77ddfc1b1b49\",\n    \"title\": \"My Neighbor Totoro\",\n    \"description\": \"Two sisters move to the country with their father in order to be closer to their hospitalized mother, and discover the surrounding trees are inhabited by Totoros, magical spirits of the forest. When the youngest runs away from home, the older sister seeks help from the spirits to find her.\",\n    \"director\": \"Hayao Miyazaki\",\n    \"producer\": \"Hayao Miyazaki\",\n    \"release_date\": \"1988\",\n    \"rt_score\": \"93\",\n    \"people\": [\n      \"https://ghibliapi.fly.dev/people/986faac6-67e3-4fb8-a9ee-bad077c2e7fe\",\n      \"https://ghibliapi.fly.dev/people/d5df3c04-f355-4038-833c-83bd3502b6b9\",\n      \"https://ghibliapi.fly.dev/people/3031caa8-eb1a-41c6-ab93-dd091b541e11\",\n
 ```
 
 That's a JSON object, which is fine, but we don't want to work in JSON, we want to work in something we are familiar with and easier to handle, a Ruby hash. So how can we convert one to the other?
@@ -120,11 +120,11 @@ So we now have this:
   :producer=>"Isao Takahata",
   :release_date=>"1986",
   :rt_score=>"95",
-  :people=>["https://ghibliapi.herokuapp.com/people/"],
-  :species=>["https://ghibliapi.herokuapp.com/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"],
-  :locations=>["https://ghibliapi.herokuapp.com/locations/"],
-  :vehicles=>["https://ghibliapi.herokuapp.com/vehicles/"],
-  :url=>"https://ghibliapi.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"},
+  :people=>["https://ghibliapi.fly.dev/people/"],
+  :species=>["https://ghibliapi.fly.dev/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"],
+  :locations=>["https://ghibliapi.fly.dev/locations/"],
+  :vehicles=>["https://ghibliapi.fly.dev/vehicles/"],
+  :url=>"https://ghibliapi.fly.dev/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"},
  {:id=>"12cfb892-aac0-4c5b-94af-521852e46d6a",
   :title=>"Grave of the Fireflies",
   :description=>
@@ -133,9 +133,9 @@ So we now have this:
   :producer=>"Toru Hara",
   :release_date=>"1988",
   :rt_score=>"97",
-  :people=>["https://ghibliapi.herokuapp.com/people/"],
-  :species=>["https://ghibliapi.herokuapp.com/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"],
-  :locations=>["https://ghibliapi.herokuapp.com/locations/"],
+  :people=>["https://ghibliapi.fly.dev/people/"],
+  :species=>["https://ghibliapi.fly.dev/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"],
+  :locations=>["https://ghibliapi.fly.dev/locations/"],
 ...
 ```
 
@@ -192,7 +192,7 @@ The first refactoring step would be to move everything into an object that will 
 ```
 class FilmSearch
   def film_information
-    response = HTTParty.get("https://ghibliapi.herokuapp.com/films")
+    response = HTTParty.get("https://ghibliapi.fly.dev/films")
     parsed_films = JSON.parse(response, symbolize_names: true)
     parsed_films.map do |data|
       Film.new(data)
@@ -239,7 +239,7 @@ So now, let's move onto the service.
 ```
 class GhibliService
   def films
-    response = HTTParty.get("https://ghibliapi.herokuapp.com/films")
+    response = HTTParty.get("https://ghibliapi.fly.dev/films")
     JSON.parse(response.body, symbolize_names: true)
   end
 end
@@ -250,7 +250,7 @@ This is good so far, but if we want to reuse the service, we want to reuse some 
 ```
 class GhibliService
   def films
-    get_url("https://ghibliapi.herokuapp.com/films")
+    get_url("https://ghibliapi.fly.dev/films")
   end
 
   def get_url(url)
@@ -264,7 +264,7 @@ end
 
 Write code to print out the names of all People from Studio Ghibili films
 
-Look through the documentation at https://ghibliapi.herokuapp.com/ to find the new endpoint that will give you the data you need.
+Look through the documentation at https://ghibliapi.fly.dev/ to find the new endpoint that will give you the data you need.
 
 ## Extension
 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

Updates the old Heroku links in the API Consumption lesson to working links at fly.dev. 

### Why are we making this update?

The great Heroku-ening of 2022 ¯\\\_( ツ )\_/¯
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

Students will be able to use the GhibliAPI at its new location

### What questions do you have/what do you want feedback on? (optional)

n/a
