### PR TITLE
adds repeater intermission work

### DIFF
--- a/module2/intermission_work/index.md
+++ b/module2/intermission_work/index.md
@@ -39,6 +39,22 @@ Time-box recommendations are in each section's instructions, and also included h
 1. [Intro to SQL](./sql) (6 hrs total, 2 hrs each section)
 1. [Rails Tutorial: Task Manager](https://github.com/turingschool-examples/task_manager_rails) (Until complete)
 
+### If you are Repeating
+
+Do a modifided version of the assignments above.
+
+* Complete a timed [Static Challenge](./static_challenge) (2 hrs)
+    * If you did Challenge 1 the first time, do Challenge 2, and vice versa.
+    * As you work, reference the [W3Schools HTML5 Tutorial](https://www.w3schools.com/html/default.asp) and [W3Schools CSS Tutorial](https://www.w3schools.com/css/default.asp)
+* [Intro to SQL](./sql) (3/4 hrs total, 1 hr each section)
+    * You can skip the Jumpstart Lab tutorial if you like. You can use the Checks for Understanding as a gauge of whether you  need to review it or not
+    * Work on the SQL exercises. Spend at least 1 hour in all three sections.
+    * Complete the Checks for Understanding
+* [Task Manager](https://github.com/turingschool-examples/task_manager_rails)
+    * Review your code. If you do not have a copy, use the completed repo linked at the bottom of the README.
+    * Answer the Checks for Understanding at the end of the README.
+
+
 ## Submission
 
 When you are finished, fill out [this form](https://forms.gle/cCWaRcoPer7oXm2K9).


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

Adds a section for repeaters in the m2 intermission work

### Why are we making this update?

Team decided that repeaters don't need to redo all intermission work
  
### Type of update

- [ ] Minor update/fix -- no review requested
- [x ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

Repeaters share positive thoughts
