### PR TITLE
Updates Relational Rails requirements and project index

### DIFF
--- a/module2/projects/index.md
+++ b/module2/projects/index.md
@@ -4,6 +4,6 @@ title: Module 2 - Projects
 ---
 
 * [Relational Rails](./relational_rails) - solo project, weeks 1-2
-* pair project, week 3
+* [Adopt, Don't Shop](https://github.com/turingschool-examples/adopt_dont_shop) - pair project, week 3
 * group project, weeks 4-5
 * final solo project, week 6

--- a/module2/projects/relational_rails/index.md
+++ b/module2/projects/relational_rails/index.md
@@ -13,9 +13,10 @@ title: Relational Rails
 
 ## Requirements
 
-- must use Rails 5.2.x
-- must use PostgreSQL
-- must "handroll" all routes (no use of `resources` syntax)
+- Must use Rails 5.2.x
+- Must use PostgreSQL
+- Must "handroll" all routes (no use of `resources` syntax)
+- Use of `scope` syntax is not permitted on this project
 
 ## Permission
 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description
Adds requirement onto Relational Rails that disallows use of `scope` for the project. 
Updates project index for pair project 2301.

### Why are we making this update?

Students were using `scope` after being informed by a mentor that it's "better", but were still learning about class methods. The team thinks students should have a better understanding of the basic class method syntax before learning and using `scope` in models. 

  
### Type of update

- [ ] Minor update/fix -- no review requested
- [x] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

In the next inning, students will be more comfortable with class method syntax and its correct implementation in regard to AR before using scope. 

### What questions do you have/what do you want feedback on? (optional)
n/a