### PR TITLE
Remove video presentation requirements for battleship and connect four

### DIFF
--- a/module1/projects/battleship/evaluation.md
+++ b/module1/projects/battleship/evaluation.md
@@ -5,9 +5,7 @@ length: 2 week
 type: project
 ---
 
-For the project eval, you should prepare a 10 minute video presentation that clearly demonstrates the presentation points listed below. To create your video presentation, we suggest hopping on a zoom call with your partner, sharing your screen, and recording your meeting as you go through the presentation points. Then, upload that video to either your Google Drive or YouTube. When submitting, the survey form will ask for your presentation video link.
-
-The technical presentation portion is outlined below with what points should be covered. If you have questions about the presentation, please let an instructor know before the time it's due.
+For the project eval, you should prepare to speak to the presentation points listed below. If you have questions about the presentation, please let an instructor know before the time it's due.
 
 
 ## Presentation points:

--- a/module1/projects/battleship/rubric.md
+++ b/module1/projects/battleship/rubric.md
@@ -7,7 +7,7 @@ _[Back to Battleship Home](./index)_
 
 ## Creating a Presentation for Evaluation
 
-Please reference [these instructions](./evaluation), to prepare a video presentation to submit for evaluation.
+Please reference [these instructions](./evaluation), to prepare for your project evaluation.
 
 ## Evaluation Rubric
 

--- a/module1/projects/connect_four/evaluation.md
+++ b/module1/projects/connect_four/evaluation.md
@@ -5,11 +5,7 @@ length: 2 week
 type: project
 ---
 
-For the project eval, you should prepare a 10 minute video presentation that clearly demonstrates the presentation points listed below. To create your video presentation, we suggest hopping on a zoom call with your partner, sharing your screen, and recording your meeting as you go through the presentation points. Then, upload that video to either google drive or youtube. When submitting, the survey form will ask for a link to your presentation video link. 
-
-The technical presentation portion is outlined below with what points should be covered. If you have questions about the presentation, please let an instructor know before the time it's due.
-
-
+For the project eval, you should prepare to speak to the presentation points listed below. If you have questions about the presentation, please let an instructor know before the time it's due.
 
 ## Presentation points:
 

--- a/module1/projects/connect_four/rubric.md
+++ b/module1/projects/connect_four/rubric.md
@@ -5,9 +5,8 @@ title: Connect Four - Evaluation Requirements
 
 _[Back to Connect Four Home](./index)_
 
-## Creating a Presentation for Evaluation
 
-Please reference [these instructions](./evaluation), to prepare a video presentation to submit for evaluation.
+Please reference [these instructions](./evaluation), to prepare for your project evaluation.
 
 ## Evaluation Rubric
 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

M1 Paired Projects: Remove requirements for video presentations

### Why are we making this update?

We will conduct live evals this inning and do not need students to pre-submit a video.
  
### Type of update

- [ ] Minor update/fix -- no review requested
- [x] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

n/a

### What questions do you have/what do you want feedback on? (optional)

n/a
