### PR TITLE
Adds mod-mod practice to IC practices page for reference

### DIFF
--- a/module2/exercises.md
+++ b/module2/exercises.md
@@ -24,6 +24,7 @@ layout: page
 ## Independent Challenge Practices
 - [Cabot Cove College](https://github.com/turingschool-examples/cabot-cove-college-b2) (Week 2)
 - [Apollo 14](https://github.com/turingschool-projects/apollo_14) (Week 2)
+- [Ticket, Please](https://github.com/turingschool-examples/b2-mid-mod) (Mid-Mod practice)
 - [Vending Machine Tracker](https://github.com/turingschool-examples/vending-machine-tracker/tree/master) (Week 4)
 - [The Final Rose](https://github.com/turingschool-examples/the_final_rose) - Longer than an actual in class challenge, but could be good preparation before Week 4 challenge, or prep for the final. 
 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

Students don't always poke around enough to find the mid-mod practice repo on the Assessments page, so making a link to the repo where they normally look for IC practice. 

### Why are we making this update?

To make finding mid-mod practice easier for students. 
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

Students will be able to practice the mid-mod sooner.

### What questions do you have/what do you want feedback on? (optional)
n/a