### PR TITLE
M2: Updates data validations & sad path testing lessons

### DIFF
--- a/module2/lessons/data_validation.md
+++ b/module2/lessons/data_validation.md
@@ -12,7 +12,7 @@ layout: page
 
 ## Set Up
 
-We'll start this lesson using [this branch](https://github.com/turingschool-examples/set-list-7/tree/generic-start) of our Set List repo.
+We'll start this lesson using [this branch](https://github.com/turingschool-examples/set-list-7/tree/data-validations-setup) of our Set List repo.
 
 ## Consider This
 
@@ -104,9 +104,11 @@ Use [ShouldaMatchers](https://github.com/thoughtbot/shoulda-matchers) and [va
 **Basics**
 - Add a validation that validates the uniqueness of an Artist's name
 - Add a validation that validates the presence of a Playlist's name
-- Add a validation for the `play_count` column that validates numericality
+- Add a validation for the Song's `play_count` column that validates numericality
 - Add a validation that adds a max length for a Song title
 - Add a validation to check for the presence of a boolean value for one of your models.
+
+You can find a completed set of these basic examples in [this branch](https://github.com/turingschool-examples/set-list-7/tree/data-validations-complete). 
 
 **Advanced**
 - Access validation errors when a validation fails on a model in your console

--- a/module2/lessons/sad_path_and_flash.md
+++ b/module2/lessons/sad_path_and_flash.md
@@ -177,6 +177,8 @@ To fix this issue, add `data: {turbo: false}` to your `form_with` tag. Example:
 <%= form_with url: "/my-path", method: :post, data: {turbo: false}, local: true do |form| %>
 ```
 
+You can read more about this issue [here](https://www.hotrails.dev/turbo-rails/flash-messages-hotwire). 
+
 
 ## `flash` Objects
 

--- a/module2/lessons/sad_path_and_flash.md
+++ b/module2/lessons/sad_path_and_flash.md
@@ -167,6 +167,16 @@ class ArtistsController < ApplicationController
   end
 end
 ```
+## `Turbo` gotcha
+As of Rails 7, Rails includes [Turbo](https://github.com/hotwired/turbo-rails) to help make pages load faster. Turbo and Rails' ActionView Helpers can sometimes get *too* eager to help, and end up causing a JavaScript error. You'll know you're having this error if your flash message doesn't show up on the screen when it's supposed to.
+
+
+To fix this issue, add `data: {turbo: false}` to your `form_with` tag. Example: 
+
+```erb
+<%= form_with url: "/my-path", method: :post, data: {turbo: false}, local: true do |form| %>
+```
+
 
 ## `flash` Objects
 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description
Changes starting and ending repos for the Data Validation lesson, so it includes workable models for the practices at the end of the lesson. 
Adds note on new Turbo gotcha to Sad Path testing lesson. 

### Why are we making this update?
Set List Tutorial repo branches got messed up for data validation lesson, oops. The Turbo "bug" stops users from being able to see the correctly-implemented flash message in a sad path, so adding a small code snippet to `form_with` works around it. 

### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 
Students will be able to start and end the data validation lesson according to the set list tutorial. 
Students will be able to correctly implement a sad path/flash message with a Turbo workaround. 

### What questions do you have/what do you want feedback on? (optional)
n/a