### PR TITLE
Adds note for Render deployments

### DIFF
--- a/module2/misc/deploying_with_render.md
+++ b/module2/misc/deploying_with_render.md
@@ -57,6 +57,7 @@ At any time, you can see your applications on Render from a high-level by going 
 
 ## Troubleshooting
 - If the build fails, you will see a message like `==> Build failed 😞` in the dashboard terminal, and it will send you an e-mail notification. Any build errors or deployment issues will be listed in the terminal above this message. 
+- If during your deploy you see a message in Render's console that says `rails: command not found`, run the following command in your local terminal: `bundle lock --add-platform x86_64-linux`. This will allow Render's server architecture to run your application. 
 - Note that the Free tier of the Web Service does not allow for SSH console, so you can't use `rails c` on the dashboard unfortunately.  
 - You can [read more about the Free tier limitations](https://render.com/docs/free#free-web-services) if you encounter other issues. 
 - Further troubleshooting documentation can be found on [Render's website](https://render.com/docs/deploy-rails).  


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description
Adding a troubleshooting tip if a repo doesn't include a platform listed compatible with Render's server arch

### Why are we making this update?
Students aren't expected to know this as part of curriculum, so adding this in as a troubleshooting tip so that they can deploy and get back to coding quicker. I don't intend to add any more to this guide or update it in the future. 
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 
Students should be able to quickly deploy their projects using Render by following the guide, or with light googling

### What questions do you have/what do you want feedback on? (optional)
n/a