### PR TITLE
Adds GH Pack signup step to m2 intermission work

### DIFF
--- a/module2/intermission_work/index.md
+++ b/module2/intermission_work/index.md
@@ -29,15 +29,17 @@ This Gist will be your submission for your intermission work. Each of the assign
 Work on the following assignments in order. Each assignment will assume that you have completed the previous one and the accompanying Checks for Understanding. **Ruby 3.2.2 and Rails 7.0.5.x are required.**
 
 Time-box recommendations are in each section's instructions, and also included here for convenience. 
-
-1. [Ruby and Rails versions installation guide](https://backend.turing.edu/module3/misc/ruby_and_rails_versions)
-2. [Get Module 2 Tools](./tools)
-3. Styling (4 hrs total)
+1. Sign up for the [GitHub Student Developer Pack](https://education.github.com/pack), using your `@turing.edu` email address. 
+   - This step sometimes takes a few days for GitHub to complete, but once you sign up for your credits you'll be able to take advantage of their benefits! 
+   - Follow [these instructions](https://mod4.turing.edu/lessons/intermission/gh-student-instructions.html) to get the info you require to complete registration. Ask in #codehelp if you get stuck. 
+2. [Ruby and Rails versions installation guide](https://backend.turing.edu/module3/misc/ruby_and_rails_versions)
+3. [Get Module 2 Tools](./tools)
+4. Styling (4 hrs total)
     * [Intro to HTML](./html)
     * [Intro to CSS](./css)
     * [Static Challenge](./static_challenge) (2h)
-4. [Intro to SQL](./sql) (6 hrs total, 2 hrs each section)
-5. [Rails Tutorial: Task Manager](https://github.com/turingschool-examples/task_manager_rails) (Until complete)
+5. [Intro to SQL](./sql) (6 hrs total, 2 hrs each section)
+6. [Rails Tutorial: Task Manager](https://github.com/turingschool-examples/task_manager_rails) (Until complete)
 
 ### If you are Repeating
 

--- a/module2/intermission_work/index.md
+++ b/module2/intermission_work/index.md
@@ -31,7 +31,7 @@ Work on the following assignments in order. Each assignment will assume that you
 Time-box recommendations are in each section's instructions, and also included here for convenience. 
 1. Sign up for the [GitHub Student Developer Pack](https://education.github.com/pack), using your `@turing.edu` email address. 
    - This step sometimes takes a few days for GitHub to complete, but once you sign up for your credits you'll be able to take advantage of their benefits! 
-   - Follow [these instructions](https://mod4.turing.edu/lessons/intermission/gh-student-instructions.html) to get the info you require to complete registration. Ask in #codehelp if you get stuck. 
+   - Follow [these instructions](https://mod4.turing.edu/lessons/intermission/gh-student-instructions.html) to get the info you require to complete registration. **You do NOT need to complete the Heroku steps at this time!** Ask in #codehelp if you get stuck. 
 2. [Ruby and Rails versions installation guide](https://backend.turing.edu/module3/misc/ruby_and_rails_versions)
 3. [Get Module 2 Tools](./tools)
 4. Styling (4 hrs total)


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description
Adds instructions to intermission work to sign up for GH Student Developer Pack. 

### Why are we making this update?
For the past few innings we did this signup live and it was a nightmare. Although we don't require  Heroku use in m2 anymore with using Render, they may use it in m3 or 4, and can benefit from the pack anyway. 
This update does *not* advise students to complete the Heroku signup, just the GH Student Developer pack so that it is available to them to use. 

### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 
Students will enter m2 (mostly) with their GH account ready to sign up for Heroku credits if they need it. 

### What questions do you have/what do you want feedback on? (optional)
Note: We might not need this step in the future, but I figure it's better to have it than not. 