### PR TITLE
Fixing link to Bakery, updating Rails/Ruby versions

### DIFF
--- a/module2/exercises.md
+++ b/module2/exercises.md
@@ -18,7 +18,7 @@ layout: page
 - [Rails Exercises](https://github.com/turingschool/rails_exercises)
 - [Day Hike](https://github.com/turingschool-projects/day_hike)
 - [Blogger](http://backend.turing.edu/module2/misc/blogger)
-- [Bakery](https://github.com/earl-stephens/bakery)
+- [Bakery](https://github.com/turingschool-examples/bakery-b2)
 - [Routes and controllers](https://github.com/turingschool/challenges/blob/master/routes_controllers_rails.markdown).
 
 ## Independent Challenge Practices


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description
Updating link on Exercises page to a new repo called Bakery 7 that has the same exercise fom Earl Stephens' Bakery project, but updated ruby and rails versions. 

### Why are we making this update?

So that students can use the Bakery project with the current versions used in the curriculum - last updates on that old repo were 4-5 years ago. Also so we can track that repo in our turingschool-examples account. 
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 
Students should be able to use the repo as an enrichment exercise for mod 2. 

### What questions do you have/what do you want feedback on? (optional)
