### PR TITLE
Changes link for API lesson to Vercel from personal Heroku

### DIFF
--- a/module2/lessons/api_consumption_in_ruby.md
+++ b/module2/lessons/api_consumption_in_ruby.md
@@ -73,7 +73,7 @@ require "json"
 require "pry"
 ```
 
-We are going to use HTTParty in order to reach out to our API and get the results. The endpoint we have to hit is `https://ghibliapi.vercel.app/films`. (As of January 2023, an older service is no longer working, so there's no documentation for this new API yet.)
+We are going to use HTTParty in order to reach out to our API and get the results. The endpoint we have to hit is `https://ghibliapi.vercel.app/films`. You can find full documentation on this API [here](https://ghibliapi.vercel.app). 
 
 The basic syntax for how we can get a response from an API is `HTTParty.get()`, where we pass the URL for the endpoint as an argument as a string.
 

--- a/module2/lessons/api_consumption_in_ruby.md
+++ b/module2/lessons/api_consumption_in_ruby.md
@@ -73,7 +73,7 @@ require "json"
 require "pry"
 ```
 
-We are going to use HTTParty in order to reach out to our API and get the results. The endpoint we have to hit is `https://limitless-castle-00011.herokuapp.com/films`. (As of January 2023, an older service is no longer working, so there's no documentation for this new API yet.)
+We are going to use HTTParty in order to reach out to our API and get the results. The endpoint we have to hit is `https://ghibliapi.vercel.app/films`. (As of January 2023, an older service is no longer working, so there's no documentation for this new API yet.)
 
 The basic syntax for how we can get a response from an API is `HTTParty.get()`, where we pass the URL for the endpoint as an argument as a string.
 
@@ -82,7 +82,7 @@ require "httparty"
 require "json"
 require "pry"
 
-response = HTTParty.get("https://limitless-castle-00011.herokuapp.com/films")
+response = HTTParty.get("https://ghibliapi.vercel.app/films")
 binding.pry
 ```
 
@@ -93,36 +93,45 @@ The get method from HTTParty returns us a special **response object**. Let's th
     2: require "json"
     3: require "pry"
     4:
-    5: response = HTTParty.get("https://limitless-castle-00011.herokuapp.com/films")
+    5: response = HTTParty.get("https://ghibliapi.vercel.app/films")
  => 6: binding.pry
 
 [1] pry(main)> response
 
-[{"id"=>"2baf70d1-42bb-4437-b551-e5fed5a87abe",
-  "title"=>"Castle in the Sky",
-  "original_title"=>"天空の城ラピュタ",
-  "original_title_romanised"=>"Tenkū no shiro Rapyuta",
-  "image"=>"https://image.tmdb.org/t/p/w600_and_h900_bestv2/npOnzAbLh6VOIu3naU5QaEcTepo.jpg",
-  "movie_banner"=>"https://image.tmdb.org/t/p/w533_and_h300_bestv2/3cyjYtLWCBE1uvWINHFsFnE8LUK.jpg",
-  "description"=>
-   "The orphan Sheeta inherited a mysterious crystal that links her to the mythical sky-kingdom of Laputa. With the help of resourceful Pazu and a rollicking band of sky pirates, she makes her way to the ruins of the once-great civilization. Sheeta and Pazu must outwit the evil Muska, who plans to use Laputa's science to make himself ruler of the world.",
-  "director"=>"Hayao Miyazaki",
-  "producer"=>"Isao Takahata",
-  "release_date"=>"1986",
-  "running_time"=>"124",
-  "rt_score"=>"95",
-  "people"=>
-   ["https://limitless-castle-00011.herokuapp.com/people/598f7048-74ff-41e0-92ef-87dc1ad980a9",
-    "https://limitless-castle-00011.herokuapp.com/people/fe93adf2-2f3a-4ec4-9f68-5422f1b87c01",
-    "https://limitless-castle-00011.herokuapp.com/people/3bc0b41e-3569-4d20-ae73-2da329bf0786",
-    "https://limitless-castle-00011.herokuapp.com/people/40c005ce-3725-4f15-8409-3e1b1b14b583",
-    "https://limitless-castle-00011.herokuapp.com/people/5c83c12a-62d5-4e92-8672-33ac76ae1fa0",
-    "https://limitless-castle-00011.herokuapp.com/people/e08880d0-6938-44f3-b179-81947e7873fc",
-    "https://limitless-castle-00011.herokuapp.com/people/2a1dad70-802a-459d-8cc2-4ebd8821248b"],
-  "species"=>["https://limitless-castle-00011.herokuapp.com/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"],
-  "locations"=>["https://limitless-castle-00011.herokuapp.com/locations/"],
-  "vehicles"=>["https://limitless-castle-00011.herokuapp.com/vehicles/4e09b023-f650-4747-9ab9-eacf14540cfb"],
-  "url"=>"https://limitless-castle-00011.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"},
+[
+  {
+    "id": "2baf70d1-42bb-4437-b551-e5fed5a87abe",
+    "title": "Castle in the Sky",
+    "original_title": "天空の城ラピュタ",
+    "original_title_romanised": "Tenkū no shiro Rapyuta",
+    "image": "https://image.tmdb.org/t/p/w600_and_h900_bestv2/npOnzAbLh6VOIu3naU5QaEcTepo.jpg",
+    "movie_banner": "https://image.tmdb.org/t/p/w533_and_h300_bestv2/3cyjYtLWCBE1uvWINHFsFnE8LUK.jpg",
+    "description": "The orphan Sheeta inherited a mysterious crystal that links her to the mythical sky-kingdom of Laputa. With the help of resourceful Pazu and a rollicking band of sky pirates, she makes her way to the ruins of the once-great civilization. Sheeta and Pazu must outwit the evil Muska, who plans to use Laputa's science to make himself ruler of the world.",
+    "director": "Hayao Miyazaki",
+    "producer": "Isao Takahata",
+    "release_date": "1986",
+    "running_time": "124",
+    "rt_score": "95",
+    "people": [
+      "https://ghibliapi.vercel.app/people/598f7048-74ff-41e0-92ef-87dc1ad980a9",
+      "https://ghibliapi.vercel.app/people/fe93adf2-2f3a-4ec4-9f68-5422f1b87c01",
+      "https://ghibliapi.vercel.app/people/3bc0b41e-3569-4d20-ae73-2da329bf0786",
+      "https://ghibliapi.vercel.app/people/40c005ce-3725-4f15-8409-3e1b1b14b583",
+      "https://ghibliapi.vercel.app/people/5c83c12a-62d5-4e92-8672-33ac76ae1fa0",
+      "https://ghibliapi.vercel.app/people/e08880d0-6938-44f3-b179-81947e7873fc",
+      "https://ghibliapi.vercel.app/people/2a1dad70-802a-459d-8cc2-4ebd8821248b"
+    ],
+    "species": [
+      "https://ghibliapi.vercel.app/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"
+    ],
+    "locations": [
+      "https://ghibliapi.vercel.app/locations/"
+    ],
+    "vehicles": [
+      "https://ghibliapi.vercel.app/vehicles/4e09b023-f650-4747-9ab9-eacf14540cfb"
+    ],
+    "url": "https://ghibliapi.vercel.app/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"
+  },
 ```
 
 This looks like it's just JSON object, but it's actually a **response object**. We can verify this by calling the class method on it. HTTParty is designed to let us see the response's body if we just look at the object.
@@ -132,7 +141,7 @@ There's a lot of information in there, but we are really only concerned with the
 So we look at what `response.body` will return.
 
 ```ruby
-"[\n  {\n    \"id\": \"2baf70d1-42bb-4437-b551-e5fed5a87abe\",\n    \"title\": \"Castle in the Sky\",\n    \"description\": \"The orphan Sheeta inherited a mysterious crystal that links her to the mythical sky-kingdom of Laputa. With the help of resourceful Pazu and a rollicking band of sky pirates, she makes her way to the ruins of the once-great civilization. Sheeta and Pazu must outwit the evil Muska, who plans to use Laputa's science to make himself ruler of the world.\",\n    \"director\": \"Hayao Miyazaki\",\n    \"producer\": \"Isao Takahata\",\n    \"release_date\": \"1986\",\n    \"rt_score\": \"95\",\n    \"people\": [\n      \"https://limitless-castle-00011.herokuapp.com/people/\"\n    ],\n    \"species\": [\n      \"https://limitless-castle-00011.herokuapp.com/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2\"\n    ],\n    \"locations\": [\n      \"https://limitless-castle-00011.herokuapp.com/locations/\"\n    ],\n    \"vehicles\": [\n      \"https://limitless-castle-00011.herokuapp.com/vehicles/\"\n    ],\n    \"url\": \"https://limitless-castle-00011.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe\"\n  },\n  {\n    \"id\": \"12cfb892-aac0-4c5b-94af-521852e46d6a\",\n    \"title\": \"Grave of the Fireflies\",\n    \"description\": \"In the latter part of World War II, a boy and his sister, orphaned when their mother is killed in the firebombing of Tokyo, are left to survive on their own in what remains of civilian life in Japan. The plot follows this boy and his sister as they do their best to survive in the Japanese countryside, battling hunger, prejudice, and pride in their own quiet, personal battle.\",\n    \"director\": \"Isao Takahata\",\n    \"producer\": \"Toru Hara\",\n    \"release_date\": \"1988\",\n    \"rt_score\": \"97\",\n    \"people\": [\n      \"https://limitless-castle-00011.herokuapp.com/people/\"\n    ],\n    \"species\": [\n      \"https://limitless-castle-00011.herokuapp.com/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2\"\n    ],\n    \"locations\": [\n      \"https://limitless-castle-00011.herokuapp.com/locations/\"\n    ],\n    \"vehicles\": [\n      \"https://limitless-castle-00011.herokuapp.com/vehicles/\"\n    ],\n    \"url\": \"https://limitless-castle-00011.herokuapp.com/films/12cfb892-aac0-4c5b-94af-521852e46d6a\"\n  },\n  {\n    \"id\": \"58611129-2dbc-4a81-a72f-77ddfc1b1b49\",\n    \"title\": \"My Neighbor Totoro\",\n    \"description\": \"Two sisters move to the country with their father in order to be closer to their hospitalized mother, and discover the surrounding trees are inhabited by Totoros, magical spirits of the forest. When the youngest runs away from home, the older sister seeks help from the spirits to find her.\",\n    \"director\": \"Hayao Miyazaki\",\n    \"producer\": \"Hayao Miyazaki\",\n    \"release_date\": \"1988\",\n    \"rt_score\": \"93\",\n    \"people\": [\n      \"https://limitless-castle-00011.herokuapp.com/people/986faac6-67e3-4fb8-a9ee-bad077c2e7fe\",\n      \"https://limitless-castle-00011.herokuapp.com/people/d5df3c04-f355-4038-833c-83bd3502b6b9\",\n      \"https://limitless-castle-00011.herokuapp.com/people/3031caa8-eb1a-41c6-ab93-dd091b541e11\",\n
+"[\n  {\n    \"id\": \"2baf70d1-42bb-4437-b551-e5fed5a87abe\",\n    \"title\": \"Castle in the Sky\",\n    \"description\": \"The orphan Sheeta inherited a mysterious crystal that links her to the mythical sky-kingdom of Laputa. With the help of resourceful Pazu and a rollicking band of sky pirates, she makes her way to the ruins of the once-great civilization. Sheeta and Pazu must outwit the evil Muska, who plans to use Laputa's science to make himself ruler of the world.\",\n    \"director\": \"Hayao Miyazaki\",\n    \"producer\": \"Isao Takahata\",\n    \"release_date\": \"1986\",\n    \"rt_score\": \"95\",\n    \"people\": [\n      \"https://ghibliapi.vercel.app/people/\"\n    ],\n    \"species\": [\n      \"https://ghibliapi.vercel.app/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2\"\n    ],\n    \"locations\": [\n      \"https://ghibliapi.vercel.app/locations/\"\n    ],\n    \"vehicles\": [\n      \"https://ghibliapi.vercel.app/vehicles/\"\n    ],\n    \"url\": \"https://ghibliapi.vercel.app/films/2baf70d1-42bb-4437-b551-e5fed5a87abe\"\n  },\n  {\n    \"id\": \"12cfb892-aac0-4c5b-94af-521852e46d6a\",\n    \"title\": \"Grave of the Fireflies\",\n    \"description\": \"In the latter part of World War II, a boy and his sister, orphaned when their mother is killed in the firebombing of Tokyo, are left to survive on their own in what remains of civilian life in Japan. The plot follows this boy and his sister as they do their best to survive in the Japanese countryside, battling hunger, prejudice, and pride in their own quiet, personal battle.\",\n    \"director\": \"Isao Takahata\",\n    \"producer\": \"Toru Hara\",\n    \"release_date\": \"1988\",\n    \"rt_score\": \"97\",\n    \"people\": [\n      \"https://ghibliapi.vercel.app/people/\"\n    ],\n    \"species\": [\n      \"https://ghibliapi.vercel.app/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2\"\n    ],\n    \"locations\": [\n      \"https://ghibliapi.vercel.app/locations/\"\n    ],\n    \"vehicles\": [\n      \"https://ghibliapi.vercel.app/vehicles/\"\n    ],\n    \"url\": \"https://ghibliapi.vercel.app/films/12cfb892-aac0-4c5b-94af-521852e46d6a\"\n  },\n  {\n    \"id\": \"58611129-2dbc-4a81-a72f-77ddfc1b1b49\",\n    \"title\": \"My Neighbor Totoro\",\n    \"description\": \"Two sisters move to the country with their father in order to be closer to their hospitalized mother, and discover the surrounding trees are inhabited by Totoros, magical spirits of the forest. When the youngest runs away from home, the older sister seeks help from the spirits to find her.\",\n    \"director\": \"Hayao Miyazaki\",\n    \"producer\": \"Hayao Miyazaki\",\n    \"release_date\": \"1988\",\n    \"rt_score\": \"93\",\n    \"people\": [\n      \"https://ghibliapi.vercel.app/people/986faac6-67e3-4fb8-a9ee-bad077c2e7fe\",\n      \"https://ghibliapi.vercel.app/people/d5df3c04-f355-4038-833c-83bd3502b6b9\",\n      \"https://ghibliapi.vercel.app/people/3031caa8-eb1a-41c6-ab93-dd091b541e11\",\n
 ```
 
 That's a JSON object, which is fine, but we don't want to work in JSON, we want to work in something we are familiar with and easier to handle, like a Ruby hash. So, how can we convert one to the other?
@@ -154,11 +163,11 @@ So now we have this:
   :producer=>"Isao Takahata",
   :release_date=>"1986",
   :rt_score=>"95",
-  :people=>["https://limitless-castle-00011.herokuapp.com/people/"],
-  :species=>["https://limitless-castle-00011.herokuapp.com/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"],
-  :locations=>["https://limitless-castle-00011.herokuapp.com/locations/"],
-  :vehicles=>["https://limitless-castle-00011.herokuapp.com/vehicles/"],
-  :url=>"https://limitless-castle-00011.herokuapp.com/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"},
+  :people=>["https://ghibliapi.vercel.app/people/"],
+  :species=>["https://ghibliapi.vercel.app/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"],
+  :locations=>["https://ghibliapi.vercel.app/locations/"],
+  :vehicles=>["https://ghibliapi.vercel.app/vehicles/"],
+  :url=>"https://ghibliapi.vercel.app/films/2baf70d1-42bb-4437-b551-e5fed5a87abe"},
  {:id=>"12cfb892-aac0-4c5b-94af-521852e46d6a",
   :title=>"Grave of the Fireflies",
   :description=>
@@ -167,9 +176,9 @@ So now we have this:
   :producer=>"Toru Hara",
   :release_date=>"1988",
   :rt_score=>"97",
-  :people=>["https://limitless-castle-00011.herokuapp.com/people/"],
-  :species=>["https://limitless-castle-00011.herokuapp.com/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"],
-  :locations=>["https://limitless-castle-00011.herokuapp.com/locations/"],
+  :people=>["https://ghibliapi.vercel.app/people/"],
+  :species=>["https://ghibliapi.vercel.app/species/af3910a6-429f-4c74-9ad5-dfe1c4aa04f2"],
+  :locations=>["https://ghibliapi.vercel.app/locations/"],
 ...
 ```
 
@@ -210,7 +219,7 @@ require "json"
 require "pry"
 require "./lib/film"
 
-response = HTTParty.get("https://limitless-castle-00011.herokuapp.com/films")
+response = HTTParty.get("https://ghibliapi.vercel.app/films")
 
 parsed = JSON.parse(response.body, symbolize_names: true)
 
@@ -252,7 +261,7 @@ The first refactoring step would be to move everything into an **object** that
 ```ruby
 class FilmSearch
   def film_information
-    response = HTTParty.get("https://limitless-castle-00011.herokuapp.com/films")
+    response = HTTParty.get("https://ghibliapi.vercel.app/films")
     parsed_films = JSON.parse(response, symbolize_names: true)
     parsed_films.map do |data|
       Film.new(data)
@@ -305,7 +314,7 @@ So now, let's move onto the service.
 ```ruby
 class GhibliService
   def films
-    get_url("https://limitless-castle-00011.herokuapp.com/films")
+    get_url("https://ghibliapi.vercel.app/films")
   end
 
   def get_url(url)
@@ -337,8 +346,8 @@ In addition to printing the name for each person, print out the name of each fil
 
 There are multiple ways to go about this. Here are some tips:
 
-- Don't be afraid to make multiple API calls
-- Try to make the API do as much work for you as possible
+- Don't be afraid to make multiple API calls.
+- Try to make the API do as much work for you as possible!
 
 
 ### Further Reading


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description
Changes links in the b2 Intro To Apis II lesson from the herokuapp that I personally hosted, to the well-documented fully-working Vercel version, found here: https://ghibliapi.vercel.app/

### Why are we making this update?
Since the free-tier Heroku apps were shut off late 2022, I had been hosting a personal Heroku app with this API remade in Node. Since someone else got it working in Vercel with full documentation, it's time for my little Node abomination to finally be put to rest.
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 
Students will be able to use the Ghibli API (hosted on Vercel) and reference its full documentation alongside their Intro to Apis II lesson. 

### What questions do you have/what do you want feedback on? (optional)
n/a
