### PR TITLE
Add links back to index to Consultancy project spec

### DIFF
--- a/module3/projects/consultancy/development.md
+++ b/module3/projects/consultancy/development.md
@@ -3,6 +3,7 @@ layout: page
 title: Consultancy - Development
 type: project
 ---
+_[Back to Consultancy Home](./index)_ 
 
 We will be using an Agile process during the development of this project. This will include:
 

--- a/module3/projects/consultancy/evaluation/feature_delivery.md
+++ b/module3/projects/consultancy/evaluation/feature_delivery.md
@@ -3,7 +3,9 @@ layout: page
 title: Consultancy - Evaluation
 type: project
 ---
+_[Back to Consultancy Home](../index)_ 
 
+_[Back to Evaluation Index](./index)_ 
 ## Feature Delivery 
 
 Each Repo meets the following:

--- a/module3/projects/consultancy/evaluation/index.md
+++ b/module3/projects/consultancy/evaluation/index.md
@@ -3,7 +3,7 @@ layout: page
 title: Consultancy - Evaluation
 type: project
 ---
-
+_[Back to Consultancy Home](../index)_ 
 ## Evaluation at a High Level
 
 Each category has specific criteria to help guide the "above and beyond" goals.

--- a/module3/projects/consultancy/evaluation/presentation_documentation.md
+++ b/module3/projects/consultancy/evaluation/presentation_documentation.md
@@ -3,7 +3,9 @@ layout: page
 title: Consultancy - Evaluation
 type: project
 ---
+_[Back to Consultancy Home](../index)_ 
 
+_[Back to Evaluation Index](./index)_ 
 ## Presentation and Documentation
 
 __Choose either Live Demo or Video Presentation to Complete:__

--- a/module3/projects/consultancy/evaluation/technical_quality.md
+++ b/module3/projects/consultancy/evaluation/technical_quality.md
@@ -3,6 +3,9 @@ layout: page
 title: Consultancy - Evaluation
 type: project
 ---
+_[Back to Consultancy Home](../index)_ 
+
+_[Back to Evaluation Index](./index)_ 
 
 ### Technical Quality
 

--- a/module3/projects/consultancy/evaluation/testing.md
+++ b/module3/projects/consultancy/evaluation/testing.md
@@ -3,7 +3,9 @@ layout: page
 title: Consultancy - Evaluation
 type: project
 ---
+_[Back to Consultancy Home](../index)_ 
 
+_[Back to Evaluation Index](./index)_ 
 ## Testing
 
 Each Repo meets the following:

--- a/module3/projects/consultancy/ideation.md
+++ b/module3/projects/consultancy/ideation.md
@@ -3,7 +3,7 @@ layout: page
 title: Consultancy - Ideation
 type: project
 ---
-
+_[Back to Consultancy Home](./index)_ 
 ## Timeline
 
 * End of Week 2: Students begin brainstorming project ideas individually using the following guidelines.

--- a/module3/projects/consultancy/inception.md
+++ b/module3/projects/consultancy/inception.md
@@ -3,7 +3,7 @@ layout: page
 title: Consultancy - Inception
 type: project
 ---
-
+_[Back to Consultancy Home](./index)_ 
 ## Background
 
 An Inception is a process used by many companies in the Software Industry to design a solution to a problem. It is tempting to take a problem and immediately start coding, however this will often result in an incoherent solution, or even worse, a solution to the **wrong** problem.

--- a/module3/projects/consultancy/project_goals.md
+++ b/module3/projects/consultancy/project_goals.md
@@ -5,7 +5,7 @@ length: 2 weeks
 tags:
 type: project
 ---
-
+_[Back to Consultancy Home](./index)_ 
 ## Learning Goals
 
 Below are technical goals that you should be applying in this project. The priority of these goals are demonstrated using a star grading system.


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

Add links back to Index from Consultancy description pages

### Why are we making this update?

Hard to navigate when you end up on an "orphan" page
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

*Share any hypothesized outcomes we might observe*

### What questions do you have/what do you want feedback on? (optional)

*List any specific questions and feedback requests*
