### PR TITLE
add backlinks to m3 projects

### DIFF
--- a/module3/projects/market_money/evaluation.md
+++ b/module3/projects/market_money/evaluation.md
@@ -4,6 +4,7 @@ title: Market Money Feedback Session (Eval)
 length: 1 week
 type: project
 ---
+_[Back to Market Money Home](./index)_
 
 The 'eval' for this project is going to be a bit different than other projects in the past. We are relying on you to score yourself for this project. To do that, please submit the form provided to you from your instructors. 
 

--- a/module3/projects/market_money/extensions.md
+++ b/module3/projects/market_money/extensions.md
@@ -5,6 +5,7 @@ length: 1 week
 tags:
 type: project
 ---
+_[Back to Market Money Home](./index)_
 
 Once your Market Money project is complete, you may choose any of the following extensions for additional practice:
 

--- a/module3/projects/market_money/requirements.md
+++ b/module3/projects/market_money/requirements.md
@@ -10,6 +10,8 @@ summary:hover {
   background-color: #bbe5fa;
 }
 </style>
+
+_[Back to Market Money Home](./index)_
 # 1. Set Up
 
 1. Create a Rails API project called `market_money` (make sure you do not set up a "traditional" Rails project with a frontend, this is an API-only project): `rails new market_money -T -d postgresql --api`

--- a/module3/projects/rails_engine_lite/evaluation.md
+++ b/module3/projects/rails_engine_lite/evaluation.md
@@ -4,6 +4,7 @@ title: Rails Engine Lite Feedback Session (Eval)
 length: 1 week
 type: project
 ---
+_[Back to Rails Engine Lite Home](./index)_
 
 The 'eval' for this project is going to be a bit different than other projects in the past. We are relying on you to score yourself for this project. To do that, please submit this form. 
 

--- a/module3/projects/rails_engine_lite/extensions.md
+++ b/module3/projects/rails_engine_lite/extensions.md
@@ -5,6 +5,7 @@ length: 1 week
 tags:
 type: project
 ---
+_[Back to Rails Engine Lite Home](./index)_
 
 Once your Rails Engine project is complete, you may choose any of the following extensions for additional points:
 

--- a/module3/projects/rails_engine_lite/peer_code_review.md
+++ b/module3/projects/rails_engine_lite/peer_code_review.md
@@ -5,6 +5,7 @@ length: 1 week
 tags:
 type: project
 ---
+_[Back to Rails Engine Lite Home](./index)_
 
 You will be given a code review partner. Exchange links for the repo and then independently walk through the sections below. You should answer the review questions from each section in a notebook or in a gist. Once both partners have completed the review of **all** sections, meet with your partner to discuss the feedback from notes you've taken. *Remember that feedback should be actionable and kind.*
 

--- a/module3/projects/rails_engine_lite/requirements.md
+++ b/module3/projects/rails_engine_lite/requirements.md
@@ -5,7 +5,7 @@ length: 1 week
 tags:
 type: project
 ---
-
+_[Back to Rails Engine Lite Home](./index)_
 # 1. Set Up
 
 1. Create a Rails API project called `rails-engine` (make sure you do not set up a "traditional" Rails project with a frontend, this is an API-only project).

--- a/module3/projects/sweater_weather/requirements.md
+++ b/module3/projects/sweater_weather/requirements.md
@@ -2,7 +2,7 @@
 layout: page
 title: Whether, Sweater? Project Requirements
 ---
-
+_[Back to Sweater Weather Home](./index)_
 # Important Note about Getting Started
 
 1. This project is an API based application. __Use__ the `rails new --api and other flags` when creating your application. _Doing `rails new` which includes views, etc is NOT a correct project structure._

--- a/module3/projects/sweater_weather/rubric.md
+++ b/module3/projects/sweater_weather/rubric.md
@@ -2,7 +2,7 @@
 layout: page
 title: Sweater Weather Project Rubric
 ---
-
+_[Back to Sweater Weather Home](./index)_
 ## Evaluation Rubric
 
 ### Technical Presentation

--- a/module3/projects/viewing_party_lite/requirements.md
+++ b/module3/projects/viewing_party_lite/requirements.md
@@ -3,7 +3,7 @@ title: Viewing Party Requirements
 length: 2 weeks
 type: project
 ---
-
+_[Back to Viewing Party Home](./index)_
 
 ## Viewing Party Requirements
 

--- a/module3/projects/viewing_party_lite/rubric.md
+++ b/module3/projects/viewing_party_lite/rubric.md
@@ -2,7 +2,7 @@
 layout: page
 title: Viewing Party Project Rubric
 ---
-
+_[Back to Viewing Party Home](./index)_
 ## Viewing Party Rubric
 
 ### Completion


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

Add links from project detail pages back to project index pages for M3 projects. 

### Why are we making this update?

Easier navigation
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

