### PR TITLE
Fixes order of PD lessons for mod 3 index

### DIFF
--- a/professional_development/Mod3/coverletters_made_easy.md
+++ b/professional_development/Mod3/coverletters_made_easy.md
@@ -86,4 +86,4 @@ If you find yourself with:
 4. Have the cover letter ready by Monday of Week 5.
 
 ### Resources:
-* Here are [additional resources](/resources/cover_letter_resources) and a general checklist to guide your draft. 
+* Here are [additional resources](https://careerdev.turing.edu/resources/cover_letter_resources) and a general checklist to guide your draft. 

--- a/professional_development/Mod3/index.md
+++ b/professional_development/Mod3/index.md
@@ -6,6 +6,6 @@ title: Module 3 Professional Development
 * [Mod 3 PD Overview](./Pd_overview)
 * [Resumes and Portfolios](./resume_and_portfolio)
 * [Cover Letters Made Easy](./coverletters_made_easy)
-* [Interview Preparation- Putting It All Together](./Interview_Preparation)
 * [Behavioral Interview Preparation](./Behavioral_Interview_Preparation_Thinking_Like_an_Interviewer)
+* [Interview Preparation- Putting It All Together](./Interview_Preparation)
 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

Fixes order oops on M3 PD index page; now matches order of lessons through the regular inning. Also fixes broken link on a mod 3 PD resource.

### Why are we making this update?
so that the order of lessons on the index page is in the order that appears on the calendar. 
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 
n/a
### What questions do you have/what do you want feedback on? (optional)
n/a