### PR TITLE
Updating projects index and Viewing party formatting

### DIFF
--- a/module3/projects/index.md
+++ b/module3/projects/index.md
@@ -3,9 +3,9 @@ layout: page
 title: Module 3 - Projects
 ---
 
-* paired project, week 1
+* [Viewing Party Lite](./viewing_party_lite/) - paired project, week 1
 * solo project, week 2
-* [Consultancy Project](./consultancy), group project, week 4 and 5
+* [Consultancy Project](./consultancy) - group project, week 4 and 5
 * final solo project, week 6
 
 

--- a/module3/projects/viewing_party_lite/index.md
+++ b/module3/projects/viewing_party_lite/index.md
@@ -1,5 +1,5 @@
 ---
-title: Viewing Party
+title: Viewing Party Lite
 length: 1 week
 tags: API consumption, paired project
 type: project

--- a/module3/projects/viewing_party_lite/requirements.md
+++ b/module3/projects/viewing_party_lite/requirements.md
@@ -11,6 +11,7 @@ _[Back to Viewing Party Home](./index)_
 - Use RuboCop in project to enforce style guide
 - Test consumption of your API
 - Consume [The Movie DB API](https://developers.themoviedb.org/3/getting-started/introduction)
+  - NOTE: You must first register an account with this service and request an API key. 
 - Do [Individual Retrospective](https://github.com/jamisonordway/individual_retrospective/blob/main/module_3/viewing_party.md)
 
 **OPTIONAL**
@@ -18,21 +19,20 @@ _[Back to Viewing Party Home](./index)_
 
 
 ### Requirements
-Project specification requirements can be found [here](https://github.com/turingschool-examples/viewing_party_lite/projects/1)
+Fork from [THIS REPO](https://github.com/turingschool-examples/viewing_party_lite_7).
+
+Project specification requirements can be found [here](https://github.com/orgs/turingschool-examples/projects/3), within the base repo's Projects tab.
 
 You will need to create your own project board on your repository. Feel free to copy the cards we have on the above linked board to add to your own project board. 
 
-Fork from [THIS REPO](https://github.com/turingschool-examples/viewing_party_lite_7)
-
-Wireframes found [here](./wireframes) can be used as an additional reference
-
+Wireframes found [here](./wireframes) can be used as an additional reference for the front-end.
 
 ### Exploration Topic Ideas
 
 - Additional API consumption
-- Add functionality such that a user must accept an invite to a movie party
-- Implement basic authentication for a user 
-    * require a password field to user registration, and create log in and loggin out functionality 
+- Add functionality such that a user must accept an invite to a movie party.
+- Implement basic authentication for a user.
+    * require a password field to user registration, and create log-in/log-out functionality 
     * utilize sessions/cookies to remember a logged in user
-- Implement low level, server side caching for API calls
+- Implement low-level server-side caching for API calls.
 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description
Sets up project index for start of inning and fixes a few typos and clarifies links for Viewing Party Lite project. 

### Why are we making this update?

Making it easier for students to find and start the Viewing Party Lite paired project. 
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 
n/a
### What questions do you have/what do you want feedback on? (optional)
n/a
