### PR TITLE
B3 refactoring lesson updates

### DIFF
--- a/module3/lessons/index.md
+++ b/module3/lessons/index.md
@@ -16,7 +16,7 @@ layout: page
 
 * [Faraday and Postman](./faraday_and_postman)
 * [Testing Tools for API Consumption](./testing_tools_for_api_consumption)
-* [Refactoring API Consumption](./refactoring_api_consumption)
+* [Consuming APIs and Refactoring Patterns](./refactoring_api_consumption)
 * [Building an API in Rails](./building_a_rails_api)
 * [Customizing your API's JSON Output](./customizing_json)
 

--- a/module3/lessons/rails_encrypted_credentials.md
+++ b/module3/lessons/rails_encrypted_credentials.md
@@ -1,4 +1,9 @@
-# Rails Encrypted Credentials
+---
+layout: page
+title: Rails Encrypted Credentials
+length: 180
+tags: apis, rails, refactoring
+---
 
 ## Introduction
 

--- a/module3/lessons/switching_from_figaro_to_rails_encrypted_credentials.md
+++ b/module3/lessons/switching_from_figaro_to_rails_encrypted_credentials.md
@@ -1,11 +1,14 @@
+---
+title: Switching from Figaro to Rails Encrypted Credentials
+length: 30
+tags: 
+---
 
-Okay, so Figaro no longer works on Ruby 3.2+ and though there is a fix sitting in a PR, I don’t think that we can expect this to go away.
+As of Ruby 3.2+, Figaro no longer works as expected, and though there is at least one [fix sitting in a PR](https://github.com/laserlemon/figaro/pulls), I don’t think that we can expect this to go away.
 
-So this is a great opportunity to start using Rails Encrypted Credentials. 
+So, this is a great opportunity to start using Rails Encrypted Credentials. 
 
-First, with VS Code, you have to be able to launch it from the command line, instructions on how to do so available here:
-
-[https://code.visualstudio.com/docs/setup/mac](https://code.visualstudio.com/docs/setup/mac)
+First, with VS Code, you have to be able to launch it from the command line, instructions on how to do so available here:  [https://code.visualstudio.com/docs/setup/mac](https://code.visualstudio.com/docs/setup/mac)
 
 Rails will encrypt our credentials for us. It encrypts with a master key that is generated. This key allows us to check the encrypted credentials we may be using to a VCS such as GitHub without the fear of having them compromised. Without the key, it is useless. 
 
@@ -35,9 +38,9 @@ Generally good idea to nest things to keep ourselves organized.
 
 And now we save and close the yaml file.
 
-When you do this you should see in your terminal that your file was encrypted and saved. 
+When you do this, you should see in your terminal that your file was encrypted and saved. 
 
-Now we need to change our controller to use the key. 
+Now, we need to change our controller to use the key. 
 
 Previously you had something like this:
 
@@ -78,3 +81,18 @@ end
 ```
 
 Now to work with this with a team - its the contents of the `config/master.key` file you need to share with your teammates securely, and they need to go and create this file with that key as the contents.
+
+
+## Checking Credentials
+
+After encrypting your credentials, you will not be able to read the encrypted text at all - and that's the whole point. But to check on those values, Rails will need to decrypt the strings for us so that we can read them. To do this, within a terminal in the project, enter the following: 
+
+```bash
+rails c
+
+Rails.application.credentials
+```
+
+You should then see a list of encrypted strings; yours will likely be at the bottom of that list. Compare it to the value you encrypted originally - it should be the same. 
+
+Watch for empty spaces before or at the end of the strings, or any funny characters you're not expecting. Rails will take *literally* whatever you give it and encrypt that entire string, so an eye for detail is essential! 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description
1. Removing figaro code references from refactoring lesson
2. Updating front-facing link to Refactoring lesson to match calendar (per ACCET requirements)
3. Minor edits to refactoring lesson for readability

### Why are we making this update?
Figaro not working with Ruby 3.2+, plus incorporating Mike's lesson walkthroughs on why we should use encrypted credentials/how we can do so. 
Also, I want students to come away from the refactoring lesson with a good understanding of what facades & services are, why we use them, and _how to test them_ - the testing part in particular was lost on some students when they would create Controller tests, which we do not teach at all, and misses the point of abstraction explored in this lesson. 
  
### Type of update

- [ ] Minor update/fix -- no review requested
- [x] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 
students should bea ble to use Rails Encrypted Credentials alongside the refactoring lesson, and we should hopefully see fewer Controller tests in the future (unless students blindly listen to mentors)

### What questions do you have/what do you want feedback on? (optional)
None
