### PR TITLE
Create new Error Handling lesson plan

### DIFF
--- a/module3/lessons/error_handling.md
+++ b/module3/lessons/error_handling.md
@@ -255,7 +255,7 @@ end
 
 When you run the sad path test, it should still be passing! This is awesome, but what if we want to rescue from the `ActiveRecord::RecordNotFound` exception in other controller actions? Adding a `rescue` block to every action that uses `Book.find(params[:id])` isn't very DRY.
 
-Enter the Rails `rescue_from` syntax. Add the following line to the top of your controller:
+That's where the Rails `rescue_from` syntax comes in! `rescue_from` behaves as a Rails filter that creates a rescue for each action in this controller. 
 
 ```ruby
 class Api::V1::BooksController < ApplicationController

--- a/module3/lessons/error_handling.md
+++ b/module3/lessons/error_handling.md
@@ -17,10 +17,10 @@ tags: rails, errors, rescue, raise, eceptions
 * Use Rails built in `raise` and `rescue_from` methods
 * Take an object oriented approach to error handling
 
-## What is an Exception? (In Ruby)
+### What is an Exception? (In Ruby)
 An [exception](https://ruby-doc.org/core-2.5.3/Exception.html) represents an error condition in a program. Exceptions provide a mechanism for stopping the execution of a program. They function similarly to “break,” in that they cause the instruction pointer to jump to another location. Unlike break, the location may be another layer of the program stack. Unhandled exceptions cause Ruby programs to stop.
 
-## What is an Error? (In Ruby)
+### What is an Error? (In Ruby)
 An error is an unwanted or unexpected event, which occurs during the execution of a program, i.e. at run time, that disrupts the normal flow of the program’s instructions.
 
 ### Breakout Room Discussion - 10 minutes
@@ -99,237 +99,153 @@ Take a five minutes on your own to answer the following questions:
 * Which methods look useful on `e`?
 * Which classes does `e` inherit from?
 
-### Error Serialization
 
-According to the [json:api specification](https://jsonapi.org/format/#error-objects)
+### Error Handling in Rails
 
-**Error objects provide additional information about problems encountered while performing an operation. Error objects MUST be returned as an array keyed by errors in the top level of a JSON:API document.**
+#### Setup
+We'll be using the `error_handling_start` branch of the [Building Internal APIs repo](https://github.com/turingschool-examples/building_internal_apis_7/tree/main) for this lesson.
 
-Unfortunately, the FastJsonapi gem [does not have any hard or fast opinions](https://github.com/Netflix/fast_jsonapi/issues/53) on error handling, and thus did not build in functionality specific to errors. So, we need to handle errors on our own, while still following the json:api specification.
-
-Let's imagine a scenario where a user searches for a senator by last name, but no senator with that last name exists.
-
-If we fill in the search box with our own last name such as "Tyrrell" then we get an unhandled error. Let's handle that.
-
-Our Facade currently looks like so:
+Let's run the sad path test from `/spec/requests/api/v1/books_request_spec.rb` in isolation:
 
 ```ruby
-class CongressFacade
-  def self.house_members(state_abbreviation)
-    json = CongressService.fetch_house_members(state_abbreviation)
-    json[:results].map do |member_info|
-      HouseMember.new(member_info)
+describe "Books API" do
+  ... 
+
+  describe 'sad paths' do
+    it "will gracefully handle if a book id doesn't exist" do
+      get "/api/v1/books/1"
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(404)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+      
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("404")
+      expect(data[:errors].first[:title]).to eq("Couldn't find Book with 'id'=1")
     end
   end
-
-  def self.all_senate_members
-    CongressService.fetch_senate_members[:results][0][:members]
-  end
-
-  def self.member_by_last_name(last_name)
-    SenateMember.new(members_by_last_name(last_name).first)
-  end
-
-  def self.members_by_last_name(last_name)
-    all_senate_members.find_all {|m| m[:last_name] == last_name}
-  end
 end
 ```
 
-First, lets isolate our call to our service.
+What is the outcome of this test? Is it currently passing or failing?
+
+It's not a trick question, and if you said "failing," you're correct! We do want to return an error response of some kind, but our application never gets the chance to do so, because it is rudely interrupted by a _raised Exception_. 
+
+Remember, Exceptions are a type of error that 'fails loudly.' While this might be the desired behavior, we should still handle the Exception gracefully for a better user experience.
+
+Following the stack trace, let's put a `pry` in the `Api::V1::BooksController`:
 
 ```ruby
-def self.call_senate_service
-  @@service_result ||= CongressService.fetch_senate_members
-end
-
-def self.all_senate_members
-  call_senate_service[:results][0][:members]
-end
+  def show
+    require 'pry'; binding.pry
+    render json: BookSerializer.new(Book.find(params[:id]))
+  end
 ```
-Isolation helps on a few fronts. It's more SRP. We can properly test this method. And, we can take advantage of memoization to ensure our we only ever make one external API call per request.
 
-Because we are memomizing within a class method, we need a class variable to hold the result of our service call. An instance variable or local variable will not memoize properly.
+Running `Book.find(params[:id])` here will return the following:
+```
+ActiveRecord::RecordNotFound: Couldn't find Book with 'id'=1
+```
 
-Now, we can build in some sad path and edge case handling within our facade.
-
-We need to build in a condition that checks if the method `::members_by_last_name` returns an empty array. We can do that by changing our code:
+We can implement error handling in this controller action by rescuing from the specific Exception that was raised in the case of our sad path test. 
 
 ```ruby
-def self.member_by_last_name(last_name)
-  if !members_by_last_name(last_name).empty?
-    SenateMember.new(members_by_last_name(last_name).first)
-  else
-    # This is where we implement our error handling
-  end
-end
-
-def self.members_by_last_name(last_name)
-  # By utilizing memoization, the iteration over our all_senate_members array only happens once per request.
-  @@matches ||= all_senate_members.find_all {|m| m[:last_name] == last_name}
-end
-```
-
-So, when `::members_by_last_name` finds a match based on our query param, we create a `SenateMember` object to pass back to our controller. But, when the method doesn't find a match we need to find a way to pass an error object back to the controller.
-
-Lets dream drive this a bit.
-
-```ruby
-def self.member_by_last_name(last_name)
-  if !members_by_last_name(last_name).empty?
-    SenateMember.new(members_by_last_name(last_name).first)
-  else
-    ErrorMember.new("No members found with the last name: #{last_name}", "NOT FOUND", 404)
-  end
-end
-```
-
-I've imagined I have an object named `ErrorMember` that takes 3 arguments upon initialization. It takes a helpful message that interpolates the search query param. It takes a status message. And, it takes a status code. This current object is returning a standard [HTTP 404 message](https://en.wikipedia.org/wiki/HTTP_404), but I've created in a way that allows it to be reuseable for other errors that may occur in my program.
-
-
-If I search with a query param that does not match a senator, then I get the error:
-`NameError (uninitialized constant CongressFacade::ErrorMember):`
-
-Lets fix that!
-
-I'll create a file in `app/poros/` called `error_member.rb` with the corresponding class:
-
-```ruby
-class ErrorMember
-
-  attr_reader :error_message, :status, :code
-  def initialize(error_message, status, code)
-    @error_message = error_message
-    @status = status
-    @code = code
-  end
-end
-```
-
-Now, If I search with a query param that does not match a senator, then I get the error:
-`FastJsonapi::MandatoryField (id is a mandatory field in the jsonapi spec):`
-
-This isn't quite as helpful of an error, but it's happening because we're passing the `SenateMemberSerializer` an ErrorMember object without an id. Currently our controller looks like this:
-
-```ruby
-class CongressController < ApplicationController
-  def search
-    @member = CongressFacade.member_by_last_name(params[:search])
-    render json: SenateMemberSerializer.new(@member)
-  end
-
-  def search_state
-    @members = CongressFacade.house_members(params[:state])
-    render "welcome/index"
-  end
-end
-```
-
-Quick tangent: This is currently the same error message if I search for a current Senator with the CORRECT last name. Because we are using FastJsonapi to serialize this object, that library expects the object we pass to our serializer to have an attribute called `id`. I can add a line to my `SenateMember` to take care of this for now:
-
-```ruby
-class SenateMember
-
-  attr_reader :id,
-              :first_name,
-              :last_name,
-              :twitter_account
-  def initialize(attributes)
-    @id = 1
-    @first_name = attributes[:first_name]
-    @last_name = attributes[:last_name]
-    @twitter_account = attributes[:twitter_account]
-  end
-end
-```
-
-We will only ever render one senator, so we can hard code `id` here to be `1`, and it works when you search for a current senator such as `Sanders`. However, we know this isn't best practice, and there are some other approaches we could take for a collection, like say setting the id to `index + 1` within an `each_with_index` block. Lets just say that the fast_jsonapi API is heavily opinionated, and if we're creating workarounds for it to work, then it may not be the best tool for the job.
-
-Moving on...
-
-Lets pry in to ensure we have an `ErrorMember` object being held by `@member`
-
-```ruby
-class CongressController < ApplicationController
-  def search
-    @member = CongressFacade.member_by_last_name(params[:search])
-    require "pry"; binding.pry
-    render json: SenateMemberSerializer.new(@member)
-  end
-
-  ...
-```
-
-```bash_profile
-2: def search
-   3:   @member = CongressFacade.member_by_last_name(params[:search])
-=> 4:   require "pry"; binding.pry
-   5:   render json: SenateMemberSerializer.new(@member)
-   6: end
-
-[1] pry(#<CongressController>)> @member
-=> #<ErrorMember:0x00007fe313dd0ee8 @code=404, @error_message="No members found with the last name: Tuyr", @status="NOT FOUND">
-```
-
-It looks like that's exactly what I have, so now I need to create a path within my controller for this `ErrorMember` to be serialized.
-
-Lets do this:
-
-```ruby
-class CongressController < ApplicationController
-  def search
-    @member = CongressFacade.member_by_last_name(params[:search])
-    if @member.class == SenateMember
-      render json: SenateMemberSerializer.new(@member)
-    else
-      render json: ErrorMemberSerializer.new(@member)
+  def show
+    begin
+      render json: BookSerializer.new(Book.find(params[:id]))
+    rescue ActiveRecord::RecordNotFound => exception
+      require 'pry'; binding.pry
     end
   end
-
-  ...
 ```
 
-Now, I've dream driven a serializer that I can pass my `ErrorMember` object to.
+Run your test and verify that this part works by hitting the pry.
 
-Lets create that serializer file named `error_member_serializer.rb` and the corresponding class:
+Let's get the test to pass by returning a json error response within the `rescue`!
 
 ```ruby
+def show
+  begin
+    render json: BookSerializer.new(Book.find(params[:id]))
+  rescue ActiveRecord::RecordNotFound => exception
+    render json: {
+      errors: [
+        {
+          status: "404",
+          title: exception.message
+        }
+      ]
+    }, status: :not_found
+  end
+end
+```
 
-class ErrorMemberSerializer
+This works, but we could refactor for a simpler controller action by creating a serializer.
+
+### Hand-rolling an Error Serializer
+
+Unfortunately, the jsonapi gem doesn't do a good job of this auto-magically. We'll create one by hand.
+```
+$ touch app/serializers/error_serializer.rb
+```
+
+```ruby
+class ErrorSerializer
   def initialize(error_object)
     @error_object = error_object
   end
 end
-
 ```
 
-Notice that we are not using the fast_jsonapi for this serializer. If I search for a senator that doesn't exist with the search parameter "tu" then I'll get some JSON based on my object:
+The `ErrorSerializer` will accept a PORO as an argument to the `initialize` method. An `ErrorMessage` PORO allows us to encapsulate data about each particular error before serializing and rendering a JSON response.
 
-```json
-{
-  "error_object": {
-    "error_message": "No members found with the last name: tu",
-    "status": "NOT FOUND",
-    "code": 404
-  }
-}
-```
-
-Not quite up to the standards of json:api specification. Lets create a custom method in my serailizer to format this properly:
+Let's continue to dream-drive this behavior in the controller.
 
 ```ruby
-class ErrorMemberSerializer
+def show
+  begin
+    render json: BookSerializer.new(Book.find(params[:id]))
+  rescue ActiveRecord::RecordNotFound => exception
+    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 404))
+      .serialize_json, status: :not_found
+  end
+end
+```
+
+Time to actually create a `poros` directory and a file for `ErrorMessage`:
+```
+$ mkdir app/poros
+$ touch app/poros/error_message.rb
+```
+
+The `ErrorMessage` PORO should have two attributes-- a message and a status code.
+
+```ruby
+class ErrorMessage
+  attr_reader :message, :status_code
+
+  def initialize(message, status_code)
+    @message = message
+    @status_code = status_code
+  end
+end
+```
+
+Now we have everything we need to finish the `ErrorSerializer#serialize_json` method.
+
+```ruby
+class ErrorSerializer
   def initialize(error_object)
     @error_object = error_object
   end
 
-  def serialized_json
+  def serialize_json
     {
       errors: [
         {
-          status: @error_object.status,
-          messsage: @error_object.error_message,
-          code: @error_object.code
+          status: @error_object.status_code.to_s,
+          title: @error_object.message
         }
       ]
     }
@@ -337,35 +253,60 @@ class ErrorMemberSerializer
 end
 ```
 
-Now, I'll add the method call to `#serialized_json` in my controller to get the result that I want:
+When you run the sad path test, it should still be passing! This is awesome, but what if we want to rescue from the `ActiveRecord::RecordNotFound` exception in other controller actions? Adding a `rescue` block to every action that uses `Book.find(params[:id])` isn't very DRY.
+
+Enter the Rails `rescue_from` syntax. Add the following line to the top of your controller:
 
 ```ruby
-class CongressController < ApplicationController
-  def search
-    @member = CongressFacade.member_by_last_name(params[:search])
-    if @member.class == SenateMember
-      render json: SenateMemberSerializer.new(@member)
-    else
-      render json: ErrorMemberSerializer.new(@member).serialized_json
-    end
+class Api::V1::BooksController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_response
+
+  ...
+end
+```
+
+`:not_found_response` will direct Rails to invoke a method of the same name whenever `ActiveRecord::RecordNotFound` is raised. The Exeception will auto-magically be passed, so we need to define this method and make sure it accepts an argument.
+
+```ruby
+class Api::V1::BooksController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_response
+
+  ...
+
+  def show
+    render json: BookSerializer.new(Book.find(params[:id])) 
   end
 
   ...
+
+  def update
+    book = Book.find(params[:id])
+    book.update(book_params)
+    render json: BookSerializer.new(book)
+  end
+  
+  def destroy
+    book = Book.find(params[:id])
+    book.destroy
+    render json: BookSerializer.new(book)
+  end
+
+  private
+ 
+  def not_found_response(exception)
+    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 404))
+      .serialize_json, status: :not_found
+  end
+end
 ```
 
-Resulting in:
+This is much better, because now our `update` and `destroy` actions will handle that exception the same way. The `show` action goes back to one line, just how it was before we started this process.
 
-```json
-{
-  "errors": [
-    {
-      "status": "NOT FOUND",
-      "messsage": "No members found with the last name: tu",
-      "code": 404
-    }
-  ]
-}
-```
+We can keep our code _even more DRY_ by rescuing from a given exception across all controllers.
+
+### Practice
+
+In your breakout rooms, use inheritance to abstract the exception handling we've created so far.
 
 ### Thinking About Patterns
 
@@ -373,10 +314,7 @@ Take a few minutes on your own to answer the following questions:
 
 * What do you like about this approach?
 * What do you not like about this approach?
-* Can you think of a better approach?
-
-Instructor will now drive using a different approach to handling errors using a combination of `raise`, `rescue_from`, and serialization.
-
+* How could you use `rescue` in conjunction with ActiveRecord validations?
 
 ### Resources
 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

This PR adds a new Error Handling activity with examples of `rescue` in a Rails app.

### Why are we making this update?

The old Error Handling lesson plan was out of date and did not demonstrate core learning goals, or Rails helpers such as `rescue_from`.
  
### Type of update

- [ ] Minor update/fix -- no review requested
- [x] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

Instructor preparation for this lesson should be much more straightforward.

### What questions do you have/what do you want feedback on? (optional)

Nothing specific-- open to any and all suggestions!
