### PR TITLE
Adjusts Portfolio requirements to add PD learning goals

### DIFF
--- a/module3/misc/final_project_and_portfolio_guide.md
+++ b/module3/misc/final_project_and_portfolio_guide.md
@@ -10,39 +10,38 @@ subheading: Final Project & Portfolio Presentation
 * **Interview Prep:** The presentation of the project and the portfolio both provide students the opportunity to practice speaking technically about code implementation and decisions and work on professional storytelling.
 * **Direct Feedback:** Instructors will be able to provide direct feedback for the technical and professional presentations respectively. Students will be better prepared for an interview.
 
-### Structure
-
-#### Final Project
+## Final Project
 * Student directed presentation (15-20 minutes)
 * Instructor questions and prodding throughout
-* Please see the presentation points listed in this [rubric](../projects/sweater_weather/rubric).
+* Please see the presentation points listed in the rubric of your assigned final project.
 
-#### Portfolio Presentation
-* Student directed presentation (5-10 minutes)
+
+---
+
+## Portfolio Presentation
+* Student directed presentation (5-7 minutes)
 * Instructor feedback (3-5 minutes)
 
-Each student will deliver a 5-10 minute slide presentation in front of an instructor. The presentation consists of a professional presentation that is a reflection on your growth throughout the mod. If you are repeating the module, see the instructions below for repeaters.
+Each student will deliver a 5-7 minute slide presentation in front of an instructor. The presentation consists of a professional presentation that is a reflection on your growth throughout the mod. If you are repeating the module, see the instructions below for repeaters.
 
 Slides can include images and graphics to illustrate the concepts you plan to discuss. These may include screenshots/animated gifs of an application you created, snippets of code from your projects, diagrams of interesting concepts/structures that you used in your project(s). **Please do not just copy the questions onto the slide with bullet point answers.**
 
 #### Professional Presentation Expectations
 The professional presentation should follow a narrative format and address the following points:
 
-* Given the Gear Up discussions you've had with peers what steps are you taking to becoming the developer you want to be?
-*For example, has this shaped your interactions in group projects and ensuring that all voices get to be heard or thinking about the accessibility for users and how they may interact with your application*
+* Professional development: 
+  * Give us your elevator pitch! "So, tell me about yourself..."
+  * How has your Job Shadow experience changed/informed your idea of what a developer is & does? 
+  * What industries/positions are you interested in pursuing? Has this changed over the last few innings?
 
-* Reflecting on your career journal from the module, what is your current approach to pursuing your industries and companies of interest?
-
-* How has feedback impacted your development in this module?
-  - How has feedback conversations with peers helped prepare you for your job/career?
-  - What is something you've learned about yourself in receiving project feedback?
+* Feedback:
+  - What is something you've learned about yourself through giving/receiving project feedback?
   - What has been the most valuable piece of feedback you have received?
-  - What specific actions are you planning on taking after receiving the feedback from this inning?
 
-* What are some lessons learned that you will take with you into the next inning & into the job?
- *This can be both technical and professional*
+* Technical Achievements:
+  * Briefly describe the main technical progress you've made this inning. What's the most interesting experience or topic you learned? 
+  * Have you discovered anything new about the way you learn? 
 
-* What has your learning trajectory looked like over the past 6 weeks?
 
 ### Requirements if you will Repeat the Module
 
@@ -59,4 +58,4 @@ The professional presentation should follow a narrative format and address the f
 
 ### Submittal
 
-* Students are not required to submit any documents but instead should be prepared to give their presentation to their instructors and engage in a follow up conversation.
+* Students are not required to submit any documents but instead should be prepared to give their presentation to their instructors and engage in a follow-up conversation.


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description
Retooling Portfolio requirements to ask students the same questions they used to answer in the final PD Deliverable; this was a lot of overlap and so having students answer in the portfolio session means they synthesize all the goals of mod 3 into one presentation instead of splitting it up. 

### Why are we making this update?
No time to check and respond to each students' PD final survey; portfolio is a much better place to synthesize learning and achievements regarding both technical goals & pd. 
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 


### What questions do you have/what do you want feedback on? (optional)

*List any specific questions and feedback requests*
