### PR TITLE
Adds practice assessment info to M3 index

### DIFF
--- a/module3/index.md
+++ b/module3/index.md
@@ -26,9 +26,13 @@ In Module 3, we will look beyond the basics of building Rails web applications w
 ## Resources
 
 * [Additional Notes, Helpful Links, etc](./notes)
-* [Suggested Practice](https://github.com/turingschool-examples/M3_weekend_practice) - Broken down by week
+* [Suggested Weekly Practice](https://github.com/turingschool-examples/M3_weekend_practice) - Broken down by week
+
+### Practice Assessments
+* [API Consumption Practice - Fruits](https://github.com/turingschool-examples/fruit-api-7)
 * [Mid Mod Practice Assessment](https://github.com/turingschool-examples/parks-finder-7)
-* [Final Practice Assessment](./practice_assessments/practice_assessment)
+* [Final Practice - Nearest Fuel Station](https://github.com/turingschool-examples/nearest-fuel-station-7)
+* [Final Practice - Destination Planner](./practice_assessments/practice_assessment)
 
 ## Requirements
 

--- a/module3/practice_assessments/practice_assessment.md
+++ b/module3/practice_assessments/practice_assessment.md
@@ -25,7 +25,7 @@ We'll be working off of [`Destination Planner 7`](https://github.com/turingschoo
 git clone git@github.com:turingschool-examples/destination-planner-7.git
 cd destination-planner-7
 bundle install
-bundle exec rake db:{create,migrate,seed}
+bundle exec rails db:{create,migrate,seed}
 bundle exec rails server
 ```
 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description
Separating practice assessments on index page to make them easier to find, and adding one new practice assessment & link to old one. 
### Why are we making this update?
Students don't often ask for practice assessments, but when they do, they're not sure where to find them. They also are used to doing 5-6 practices in mods 1 & 2, so this is a chance for them to get some repetition of the API & testing skills introduced this inning. 
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 
students should feel and fare better on mid-mod and finals with additional practice. 

### What questions do you have/what do you want feedback on? (optional)
n/a