### PR TITLE
Consultancy updates

### DIFF
--- a/module3/projects/consultancy/development.md
+++ b/module3/projects/consultancy/development.md
@@ -45,7 +45,7 @@ Day 1:
   - Front-end application set up with gems configured. Ideally one or two calls to the backend have been roughly implemented
   - Backend application set up with gems configured. Ideally one or two CRUD operations for front-end consumption have been roughly implemented. 
   - Initial structure of each Service (not necessarily working API calls)
-  - [Circle-CI](https://mod4.turing.edu/lessons/Continuous-Integration-CircleCi.html) and Deployment to Heroku for both FE/BE repositories
+  - [Circle-CI](https://mod4.turing.edu/lessons/Continuous-Integration.html) and Deployment to the internet (using Heroku, Render, etc.) for both FE/BE repositories
 
 #### Sprint 2: Primary Development
 
@@ -98,14 +98,13 @@ In addition to the End of Sprint Demos, you will also have some project check in
 
 ## Continuous Integration
 
-* Set up a [CI Server](https://backend.turing.edu/module3/archive/lessons/environments_and_ci) (Optional to create more than 2 environments)
-* [CircleCI Docs](https://circleci.com/docs/2.0/)
-* [CircleCI Mod 4 Lesson](https://mod4.turing.edu/lessons/Continuous-Integration-CircleCi.html)
+* [CircleCI Docs](https://circleci.com/docs/)
+* [CircleCI Mod 4 Lesson](https://mod4.turing.edu/lessons/Continuous-Integration.html)
+* Optionally, set up a [CI Server](https://backend.turing.edu/module3/archive/lessons/environments_and_ci) (Optional to create more than 2 environments)
 
+### Continuous Deployment -- Optional
 
-## Continuous Deployment -- Optional
-
-* Set up Circle-CI in such a way that it automatically deploys its code to Heroku when 'main' branch code is passing
+* Set up Circle-CI in such a way that it automatically deploys its code to the internet (Heroku, Render, etc.) when 'main' branch code is passing.
 
 ## Story Grooming
 

--- a/module3/projects/consultancy/evaluation/feature_delivery.md
+++ b/module3/projects/consultancy/evaluation/feature_delivery.md
@@ -13,7 +13,7 @@ Each Repo meets the following:
 - 90% or more MVP stories are completed
     - [ ] Rails Front End
     - [ ] Rails Back End
-- at least 2 external APIs are consumed
+- at least 1 external API is consumed
 
 Frontend
 - [ ] OAuth works error-free in incognito/private

--- a/module3/projects/consultancy/evaluation/technical_quality.md
+++ b/module3/projects/consultancy/evaluation/technical_quality.md
@@ -36,7 +36,7 @@ Each Repo meets the following:
 - Facades, Services, and/or Serializers are used.
     - [ ] Rails Backend
 
-- Deploy to Heroku
+- Deploy to the internet (using Render, Heroku, etc)
     - [ ] Frontend
     - [ ] Rails Backend
 
@@ -61,7 +61,7 @@ __When the above criteria is met, here are additional points to achieve Exceed E
     - [ ] Frontend
     - [ ] Rails Backend
 
-- CircleCI deploys to Heroku
+- CircleCI deploys to the internet (Heroku, Render, etc.)
     - [ ] Frontend
     - [ ] Rails Backend
 

--- a/module3/projects/consultancy/evaluation/testing.md
+++ b/module3/projects/consultancy/evaluation/testing.md
@@ -14,6 +14,10 @@ Each Repo meets the following:
     - [ ] Frontend
     - [ ] Rails Backend
 
+- API calls to external services are tested using mocks/stubs in *at least one* application (using tools like Webmock, VCR, etc.)
+    - [ ] Frontend 
+    - [ ] Rails Backend
+
 
 ---
 
@@ -24,8 +28,4 @@ Frontend
 - [ ] 95% or more test coverage, every application feature has at least one sad path test
 
 - 95% or more test coverage, every exposed API endpoint and service call has at least one sad path test
-    - [ ] Rails Backend
-
-
-- API calls to external services are tested using mocks/stubs
     - [ ] Rails Backend

--- a/module3/projects/index.md
+++ b/module3/projects/index.md
@@ -6,7 +6,7 @@ title: Module 3 - Projects
 * [Viewing Party Lite](./viewing_party_lite/) - paired project, week 1
 * [Rails Engine Lite](./rails_engine_lite) - solo project, week 2
 * [Consultancy Project](./consultancy) - group project, week 4 and 5
-* final solo project, week 6
+* [Lunch and Learn](./lunch_and_learn/) - final solo project, week 6
 
 
 ### Resources

--- a/module3/projects/lunch_and_learn/index.md
+++ b/module3/projects/lunch_and_learn/index.md
@@ -23,8 +23,32 @@ Your team is working in a service-oriented architecture. The front-end will comm
 
 ## Requirements
 
-The project must expose all of the endpoints [listed here](./requirements)
+The project must expose all of the endpoints [listed here](./requirements).
+
+### Pre-Approved Gems
+
+This project will have you to consume multiple APIs - you should do so manually, without the use of SDKs/gems that may make it faster/easier. This is an assessment in part of your ability to read documentation, implement tooling required to test & consume one or more APIs manually, traverse complex external datasets, and refactor your application to do these things as efficiently as possible. 
+
+Here is a list of pre-approved gems you can use on this project: 
+```
+pry, debug, byebug
+simplecov # required
+rspec-rails
+capybara
+launchy
+webmock
+vcr 
+faraday
+jsonapi-serializer # optional
+factorybot
+faker
+bcrypt
+shoulda-matchers
+orderly
+```
+
+If you have questions about a gem that is not on this list, please reach out to your instructors *first*.
 
 ## Evaluation
 
-Your project will be evaluated based on [this rubric](./rubric)
+Your project will be evaluated based on [this rubric](./rubric).


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description
Updates consultancy project pages for accuracy - removes Heroku for 'internet', fixes link to CircleCI lesson, removes 2 apis to 1 requirement, and added mock/stubs in testing as requirement in *at least one* application (intend to make this both next inning)

### Why are we making this update?
Students were confused because we still had refenreces to 2 APIs being required to consume when we changed it back to 1. Also links to CircleCI lesson were outdated, and made it explicit that students could choose what service to host their deployments on (Heroku OR Render, etc.). 

In addition, made it explicit in the Testing portion of the rubric that mocking/stubbing external requests is required. 
  
### Type of update

- [ ] Minor update/fix -- no review requested
- [x] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 
Students should be able to access consistent relevant information on all project pages. 

### What questions do you have/what do you want feedback on? (optional)

