### PR TITLE
Removes extra :name field from lesson

### DIFF
--- a/module3/lessons/sessions_cookies_authorization.md
+++ b/module3/lessons/sessions_cookies_authorization.md
@@ -1,9 +1,8 @@
 ---
-title: Cookies, Sessions and Authorization
+title: Sessions, Cookies, and Authorization
 length: 120
 tags: cookies, session, auth, authorization
 ---
-# Sessions, Cookies, Authorization
 
 ## What Are You Allowed to Do Here?
 
@@ -428,13 +427,11 @@ describe "Admin login" do
   describe "happy path" do
     it "I can log in as an admin and get to my dashboard" do
 	    admin = User.create(username: "superuser@awesome-site.com",
-			name: "Superuser",
                         password: "super_secret_passw0rd",
                         role: 2)
 
       visit login_path
       fill_in :username, with: admin.username
-      fill_in :name, with: admin.name
       fill_in :password, with: admin.password
       click_button 'Log In'
 
@@ -446,7 +443,6 @@ end
 describe "as default user" do
   it 'does not allow default user to see admin dashboard index' do
     user = User.create(username: "fern@gully.com",
-                       name: "Default",
                        password: "password",
                        role: 0)
 


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description
Removing an errant `:name` field from the code & tests in this lesson. This field does not exist in the prior lesson and isn't added. 

### Why are we making this update?

I somehow pushed code a few months back that added a `:name` field to tests & code in this lesson; removing for clarity. 
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 
Students won't get confused when copy/pasting the test in the lesson. 

### What questions do you have/what do you want feedback on? (optional)
n/a