### PR TITLE
Add test env config for raising exceptions instead of showing pages for rescuable errors

### DIFF
--- a/module3/lessons/exercises/building_an_api.md
+++ b/module3/lessons/exercises/building_an_api.md
@@ -45,6 +45,21 @@ $ bundle
 $ rails g rspec:install
 ```
 
+By default, the Rails 7 test environment renders exception templates for rescuable exceptions. You can find this configuration in `config/environments/test.rb`:
+
+```ruby
+# Render exception templates for rescuable exceptions and raise for other exceptions.
+  config.action_dispatch.show_exceptions = :rescuable
+```
+
+Since we want the raised exception to print to our terminal in the case of failing tests, change this line to the following:
+
+```ruby
+  config.action_dispatch.show_exceptions = :none
+```
+
+The wording here is a bit misleading, but don't worry. This change makes it so that RSpec will show us any raised exceptions instead of trying to render an HTML document for the ones that are rescuable.
+
 Now let's get our factories set up!
 
 add `gem "factory_bot_rails"`, `gem "faker"` to your :development, :test block in your Gemfile. Remember to bundle afterwards.


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

Updates RSpec config instructions: set action_dispatch.show_exceptions to `:none`.

### Why are we making this update?

In newer versions of Rails, the test environment renders error pages (HTML) for rescuable exceptions by default. We should change this for TDD purposes, though a longer-term solution might be to reconsider how we teach TDD, particularly pertaining to building routes and controllers.
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

N/A

### What questions do you have/what do you want feedback on? (optional)

N/A
