### PR TITLE
Fix postman test suite typo

### DIFF
--- a/module3/projects/market_money/market_money.postman_collection.json
+++ b/module3/projects/market_money/market_money.postman_collection.json
@@ -265,7 +265,7 @@
 							"",
 							"    // test values",
 							"    pm.expect(payload.data.type).to.eq(\"vendor\")",
-							"    pm.expect(payload.data.id).to.eq(pm.globals.get('first_vendor_id').toString())",
+							"    pm.expect(payload.data.id).to.eq(pm.globals.get('vendor_id').toString())",
 							"    pm.expect(payload.data.attributes.name).to.eq(pm.globals.get('vendor_name'))",
 							"    pm.expect(payload.data.attributes.description).to.eq(pm.globals.get('vendor_description'))",
 							"    pm.expect(payload.data.attributes.contact_name).to.eq(pm.globals.get('vendor_contact_name'))",


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

Change 'first_vendor_id' to 'vendor_id' in part of the Market Money Postman test suite, based on student feedback from 2403. This appears to have been a typo.

### Why are we making this update?

  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

n/a

### What questions do you have/what do you want feedback on? (optional)

n/a