### PR TITLE
Remove REST Countries API from endpoint 1

### DIFF
--- a/module3/projects/lunch_and_learn/requirements.md
+++ b/module3/projects/lunch_and_learn/requirements.md
@@ -79,8 +79,7 @@ Example:
 
 **Requirements:**
 
-* If country is not sent in by the user, you will need to use the [REST Countries API](https://restcountries.com/#api-endpoints-v3-all) to randomly choose one country's name.
-* For whichever country is either passed in or chosen at random, find recipes using the [Edamam Recipe API](https://developer.edamam.com/edamam-recipe-api)
+* For the country sent in by the user, find recipes using the [Edamam Recipe API](https://developer.edamam.com/edamam-recipe-api)
     - Note: use the `q` parameter to search for recipes related to that country
 * If the country parameter is either an empty string, or a value that doesn't return any recipes, return an empty array:
 ```json
@@ -394,6 +393,6 @@ The response data should contain exactly these elements and nothing more:
 
 Note: We've come up with 3 extensions. If you have an idea of a different feature/technology you'd like to implement as an alternate extension, run it by your instructors to get confirmation that you can use that idea in place of an extension below. 
 
-1. For the recipes and learning resources endpoints, use the REST Countries API to validate that the country parameter passed in is in fact a valid country. If it isn't, return an appropriate [400-level status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_errors).
+1. For the recipes and learning resources endpoints, use the [REST Countries API](https://restcountries.com/#api-endpoints-v3-all) to validate that the country parameter passed in is in fact a valid country. If it isn't, return an appropriate [400-level status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_errors).
 2. Add an endpoint to DELETE a favorite ( DELETE '/api/v1/favorites')
 3. Utilize caching OR background workers to optimize API calls.


### PR DESCRIPTION
# Backend Curriculum PR Template

### Description

Removes REST Countries API requirement from endpoint 1. The ["Places" final assessment](https://github.com/turingschool/be3-assessments/blob/main/final_assessments/lunch_and_learn_assessments/places.md) has been updated to reflect this.

### Why are we making this update?

The REST Countries API has had some outages, preventing students from making progress.
  
### Type of update

- [x] Minor update/fix -- no review requested
- [ ] Moderate update -- review from Mod Team requested
- [ ] Major update -- review from Backend Team requested

### How will we measure the success of this change? 

n/a

### What questions do you have/what do you want feedback on? (optional)

n/a
